### PR TITLE
chore(deps): bump pallas to 1.0.0

### DIFF
--- a/tracker/Cargo.toml
+++ b/tracker/Cargo.toml
@@ -19,7 +19,7 @@ tx3-lift         = { git = "https://github.com/tx3-lang/tx3-lift", rev = "04d0b9
 tx3-lift-cardano = { git = "https://github.com/tx3-lang/tx3-lift", rev = "04d0b90a34b2461dd497f9941b491aed5d925bfd" }
 tx3-tir          = "0.17.0"
 tx3-sdk          = "0.11.0"
-pallas           = ">=1.0.0-alpha, <2.0.0"
+pallas           = "1.0.0"
 
 utxorpc-spec = "0.19"
 tonic        = { version = "0.12", features = ["tls", "tls-roots"] }


### PR DESCRIPTION
Bumps the `pallas` dependency in `tracker` from the pre-release range (`>=1.0.0-alpha, <2.0.0`) to the stable **`1.0.0`** release on crates.io.

`tracker` compiles cleanly against pallas 1.0.0 (`cargo check` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)