### PR TITLE
Switch SDK quickstart snippets to the codegen flow

### DIFF
--- a/frontend/app/pages/protocol/details/tab/sdks.tsx
+++ b/frontend/app/pages/protocol/details/tab/sdks.tsx
@@ -10,7 +10,12 @@ import { ChevronRightIcon } from '~/components/icons/chevron-right';
 import { getTrpForProfile, TRP_ENDPOINTS } from '~/trp-config';
 
 // Internal
-import { generateQuickStart, pickDefaultProfile, type QuickStartSnippet } from './sdks/quick-start';
+import {
+  generateQuickStart,
+  pickDefaultProfile,
+  type QuickStartSnippet,
+  type SetupStep,
+} from './sdks/quick-start';
 
 type TrpKind = 'local' | 'demeter';
 
@@ -30,7 +35,6 @@ interface SDKDef {
   name: string;
   title: string;
   icon: React.ReactNode;
-  installCommand: string;
 }
 
 const sdks: SDKDef[] = [
@@ -39,28 +43,24 @@ const sdks: SDKDef[] = [
     name: 'TypeScript',
     title: 'TypeScript SDK',
     icon: <img src="/images/sdks/typescript.png" className="w-8 h-8" />,
-    installCommand: 'npm install tx3-sdk',
   },
   {
     key: 'rust',
     name: 'Rust',
     title: 'Rust SDK',
     icon: <img src="/images/sdks/rust.png" className="w-8 h-8" />,
-    installCommand: 'cargo add tx3-sdk serde_json',
   },
   {
     key: 'go',
     name: 'Go',
     title: 'Go SDK',
     icon: <img src="/images/sdks/go.png" className="w-8 h-8" />,
-    installCommand: 'go get github.com/tx3-lang/go-sdk/sdk',
   },
   {
     key: 'python',
     name: 'Python',
     title: 'Python SDK',
     icon: <img src="/images/sdks/python.png" className="w-8 h-8" />,
-    installCommand: 'pip install tx3-sdk',
   },
 ];
 
@@ -134,36 +134,28 @@ function SectionHeading({ children }: { children: React.ReactNode; }) {
   );
 }
 
-function InlineCode({ children }: { children: React.ReactNode; }) {
-  return (
-    <code className="text-zinc-200 bg-zinc-900 px-1.5 py-0.5 rounded text-[0.9em]">
-      {children}
-    </code>
-  );
+interface SetupSectionProps {
+  steps: SetupStep[];
 }
 
-interface InstallSectionProps {
-  sdk: SDKDef;
-  protocol: Protocol;
-}
-
-function InstallSection({ sdk, protocol }: InstallSectionProps) {
-  const trixCmd = `trix add ${protocol.scope}/${protocol.name}@${protocol.version}`;
-  const tiiPath = `./.tx3/tii/${protocol.scope}/${protocol.name}.tii`;
+function SetupSection({ steps }: SetupSectionProps) {
   return (
     <section>
-      <SectionHeading>Install</SectionHeading>
-
-      <p className="text-zinc-400 text-sm mb-3">Install the SDK:</p>
-      <CodeBlock lang="bash" code={sdk.installCommand} className={codeBlockClasses} />
-
-      <p className="text-zinc-400 text-sm mt-6 mb-3">
-        Then download this protocol's compiled <InlineCode>.tii</InlineCode> file with{' '}
-        <InlineCode>trix</InlineCode>. It fetches the artifact into{' '}
-        <InlineCode>{tiiPath}</InlineCode> so your code can load it via{' '}
-        <InlineCode>Protocol.fromFile</InlineCode>.
-      </p>
-      <CodeBlock lang="bash" code={trixCmd} className={codeBlockClasses} />
+      <SectionHeading>Setup</SectionHeading>
+      <ol className="flex flex-col gap-6">
+        {steps.map((step, idx) => (
+          <li key={`${step.title}-${idx}`} className="flex flex-col gap-2">
+            <h4 className="text-sm font-semibold text-zinc-200">
+              <span className="text-zinc-500 mr-2">{idx + 1}.</span>
+              {step.title}
+            </h4>
+            {step.note && (
+              <p className="text-zinc-400 text-sm">{step.note}</p>
+            )}
+            <CodeBlock lang={step.lang} code={step.body} className={codeBlockClasses} />
+          </li>
+        ))}
+      </ol>
     </section>
   );
 }
@@ -221,7 +213,7 @@ function QuickStartSection({
           />
         </div>
       </div>
-      <CodeBlock code={snippet.setup} lang={snippet.lang} className={codeBlockClasses} />
+      <CodeBlock code={snippet.quickStart} lang={snippet.lang} className={codeBlockClasses} />
 
       {snippet.transactions.length > 0 && (
         <>
@@ -260,6 +252,14 @@ function QuickStartSection({
           </div>
         </>
       )}
+
+      <h4 className="text-sm font-semibold text-zinc-200 mt-6 mb-2">
+        Sign and submit
+      </h4>
+      <p className="text-zinc-400 text-sm mb-3">
+        Take the <code className="text-zinc-200">resolved</code> tx from any transaction above, sign it, and submit it to the network.
+      </p>
+      <CodeBlock code={snippet.lifecycle} lang={snippet.lang} className={codeBlockClasses} />
     </section>
   );
 }
@@ -350,7 +350,7 @@ export function TabSDKs({ protocol }: Props) {
 
       <section className="flex-1 min-w-0 flex flex-col gap-10 pl-10 border-l border-zinc-800">
         <h2 className="text-2xl font-semibold text-zinc-50">{selected.title}</h2>
-        <InstallSection sdk={selected} protocol={protocol} />
+        <SetupSection steps={snippet.setupSteps} />
         <QuickStartSection
           snippet={snippet}
           profiles={profiles}

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
@@ -1,10 +1,11 @@
 import {
   placeholderFor,
+  profileSuppliedNames,
   type SdkRenderer,
-  sortedProtocolParties,
-  tiiPath,
-  toCamelCase,
+  type SetupStep,
+  toPascalCase,
   type TrpConfig,
+  unboundParties,
   userProvidedParams,
 } from './shared';
 
@@ -16,105 +17,133 @@ function formatValue(value: unknown, type: string): string {
   return JSON.stringify(String(value));
 }
 
-function trpInit(trp: TrpConfig): string[] {
-  const endpoint = `        Endpoint: ${JSON.stringify(trp.endpoint)},`;
+function clientOptionsBlock(trp: TrpConfig): string[] {
+  const endpoint = `    Endpoint: ${JSON.stringify(trp.endpoint)},`;
   if (!trp.headers) {
     return [
-      '    trpClient := tx3.NewTRPClient(trp.ClientOptions{',
+      'options := trp.ClientOptions{',
       endpoint,
-      '    })',
+      '}',
     ];
   }
   const headerLines = Object.entries(trp.headers).map(([k, v]) =>
-    `            ${JSON.stringify(k)}: ${JSON.stringify(v)},`,
+    `        ${JSON.stringify(k)}: ${JSON.stringify(v)},`,
   );
   return [
-    '    trpClient := tx3.NewTRPClient(trp.ClientOptions{',
+    'options := trp.ClientOptions{',
     endpoint,
-    '        Headers: map[string]string{',
+    '    Headers: map[string]string{',
     ...headerLines,
-    '        },',
-    '    })',
+    '    },',
+    '}',
   ];
 }
 
-function setup(protocol: Protocol, profile: Profile | null, trp: TrpConfig, supplied: Set<string>): string {
-  const partyLines = sortedProtocolParties(protocol, supplied).map(p =>
-    `        WithParty(${JSON.stringify(p.name)}, tx3.AddressParty(${JSON.stringify(p.address)})).`,
-  );
+function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string {
+  const hasProfiles = (protocol.profiles ?? []).length > 0;
+  const supplied = profileSuppliedNames(profile);
+  const unbound = unboundParties(protocol, supplied);
+  const profileArg = hasProfiles && profile
+    ? `, protocol.Profile${toPascalCase(profile.name)}`
+    : '';
 
-  const clientLines = [
-    '    client := tx3.NewClient(protocol, trpClient).',
-    ...(profile ? [`        WithProfile(${JSON.stringify(profile.name)}).`] : []),
-    ...partyLines,
-  ];
-  // Strip trailing dot on the last chained call.
-  const lastIdx = clientLines.length - 1;
-  clientLines[lastIdx] = clientLines[lastIdx].replace(/\.\s*$/, '');
+  const partyLines = unbound.map((p, i) => {
+    const setter = `With${toPascalCase(p.name)}`;
+    if (i === 0) {
+      return `    .${setter}(facade.SignerParty(signer))`;
+    }
+    return `    .${setter}(facade.AddressParty(${JSON.stringify(p.address)}))`;
+  });
 
-  return [
-    'package main',
-    '',
+  const lines: string[] = [
     'import (',
     '    "context"',
     '    "log"',
     '',
-    '    tx3 "github.com/tx3-lang/go-sdk/sdk"',
+    '    "github.com/tx3-lang/go-sdk/sdk/facade"',
+    '    "github.com/tx3-lang/go-sdk/sdk/signer"',
     '    "github.com/tx3-lang/go-sdk/sdk/trp"',
+    '    "./gen/go/protocol"',
     ')',
     '',
-    'func main() {',
-    '    // 1. Load the protocol (compiled .tii file)',
-    `    protocol, err := tx3.ProtocolFromFile(${JSON.stringify(tiiPath(protocol))})`,
-    '    if err != nil {',
-    '        log.Fatal(err)',
-    '    }',
+    'ctx := context.Background()',
+    ...clientOptionsBlock(trp),
     '',
-    '    // 2. Connect to a TRP server',
-    ...trpInit(trp),
-    '',
-    '    // 3. Configure a signer (uncomment to enable .Sign() / .Submit())',
-    '    // mySigner, _ := signer.CardanoSignerFromMnemonic("addr_test1...", "word1 word2 ... word24")',
-    '',
-    `    // 4. Bind parties${profile ? ` and select the "${profile.name}" profile` : ''}`,
-    ...clientLines,
-    '',
-    '    ctx := context.Background()',
-    '',
-    '    // 5. Invoke one of the transactions listed below.',
-    '',
-    '    // 6. Once a signer is bound, chain .Sign() / .Submit() / .WaitForConfirmed():',
-    '    signed := result.Sign()',
-    '    submitted, _ := signed.Submit(ctx)',
-    '    status, _ := submitted.WaitForConfirmed(ctx, tx3.DefaultPollConfig())',
-    '    _ = status',
-    '}',
-  ].join('\n');
-}
-
-function txBlock(tx: Tx, protocol: Protocol, supplied: Set<string>): string {
-  const varName = toCamelCase(tx.name);
-  const argLines = userProvidedParams(tx, protocol, supplied).map(param =>
-    `    Arg(${JSON.stringify(param.name)}, ${formatValue(placeholderFor(param.type), param.type)}).`,
-  );
-  if (argLines.length === 0) {
-    return [
-      `${varName}, err := client.Tx(${JSON.stringify(tx.name)}).Resolve(ctx)`,
-      'if err != nil {',
-      '    log.Fatal(err)',
-      '}',
-      `_ = ${varName}`,
-    ].join('\n');
-  }
-  return [
-    `${varName}, err := client.Tx(${JSON.stringify(tx.name)}).`,
-    ...argLines,
-    '    Resolve(ctx)',
+    'mySigner, err := signer.Ed25519FromHex("addr_test1...", "deadbeef...")',
     'if err != nil {',
     '    log.Fatal(err)',
     '}',
-    `_ = ${varName}`,
+    '',
+  ];
+  if (partyLines.length === 0) {
+    lines.push(`client := protocol.NewClient(options${profileArg})`);
+  } else {
+    lines.push(`client := protocol.NewClient(options${profileArg}).`);
+    lines.push(...partyLines);
+    // Strip trailing dot on the last chained call.
+    const lastIdx = lines.length - 1;
+    lines[lastIdx] = lines[lastIdx].replace(/\.\s*$/, '');
+  }
+  return lines.join('\n');
+}
+
+function txBlock(tx: Tx, protocol: Protocol): string {
+  const supplied = profileSuppliedNames(null);
+  const params = userProvidedParams(tx, protocol, supplied);
+  const method = toPascalCase(tx.name);
+  const paramsType = `protocol.${toPascalCase(tx.name)}Params`;
+  if (params.length === 0) {
+    return [
+      `resolved, err := client.${method}(${paramsType}{}).Resolve(ctx)`,
+      'if err != nil {',
+      '    log.Fatal(err)',
+      '}',
+    ].join('\n');
+  }
+  const argLines = params.map(param =>
+    `    ${toPascalCase(param.name)}: ${formatValue(placeholderFor(param.type), param.type)},`,
+  );
+  return [
+    `resolved, err := client.${method}(${paramsType}{`,
+    ...argLines,
+    '}).Resolve(ctx)',
+    'if err != nil {',
+    '    log.Fatal(err)',
+    '}',
   ].join('\n');
 }
 
-export const goRenderer: SdkRenderer = { lang: 'go', setup, txBlock };
+function lifecycle(_protocol: Protocol): string {
+  return [
+    '// `resolved` is the result of one of the transactions above.',
+    'signed, err := resolved.Sign()',
+    'if err != nil {',
+    '    log.Fatal(err)',
+    '}',
+    'submitted, err := signed.Submit(ctx)',
+    'if err != nil {',
+    '    log.Fatal(err)',
+    '}',
+    'status, err := submitted.WaitForConfirmed(ctx, facade.DefaultPollConfig())',
+    'if err != nil {',
+    '    log.Fatal(err)',
+    '}',
+    '_ = status',
+  ].join('\n');
+}
+
+const postCodegenInstall: SetupStep = {
+  kind: 'shell',
+  lang: 'bash',
+  title: 'Install the generated client\'s dependencies',
+  body: 'cd gen/go && go mod tidy',
+  note: 'The generated go.mod declares the tx3 go-sdk; `go mod tidy` resolves it.',
+};
+
+export const goRenderer: SdkRenderer = {
+  lang: 'go',
+  postCodegenInstall,
+  quickStart,
+  txBlock,
+  lifecycle,
+};

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/index.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/index.ts
@@ -1,11 +1,12 @@
 import {
   byName,
-  profileSuppliedNames,
+  commonSetupSteps,
   type QuickStartOptions,
   type QuickStartSnippet,
   type QuickStartTx,
   type SdkRenderer,
   type SDKKey,
+  type SetupStep,
   type TrpConfig,
 } from './shared';
 import { goRenderer } from './go';
@@ -13,7 +14,7 @@ import { pythonRenderer } from './python';
 import { rustRenderer } from './rust';
 import { typescriptRenderer } from './typescript';
 
-export type { SDKKey, TrpConfig, QuickStartOptions, QuickStartTx, QuickStartSnippet };
+export type { SDKKey, TrpConfig, QuickStartOptions, QuickStartTx, QuickStartSnippet, SetupStep };
 
 // To add a new SDK: implement an `SdkRenderer` in its own file and register it here.
 const RENDERERS: Record<SDKKey, SdkRenderer> = {
@@ -46,16 +47,19 @@ export function generateQuickStart(
   options: QuickStartOptions,
 ): QuickStartSnippet {
   const { profile, trp } = options;
-  const supplied = profileSuppliedNames(profile);
   const txs = [...(protocol.transactions ?? [])].sort(byName);
   const renderer = RENDERERS[sdk];
+  const setupSteps = [...commonSetupSteps(sdk, protocol)];
+  if (renderer.postCodegenInstall) setupSteps.push(renderer.postCodegenInstall);
   return {
     lang: renderer.lang,
-    setup: renderer.setup(protocol, profile, trp, supplied),
+    setupSteps,
+    quickStart: renderer.quickStart(protocol, profile, trp),
     transactions: txs.map(tx => ({
       name: tx.name,
       description: tx.description,
-      code: renderer.txBlock(tx, protocol, supplied),
+      code: renderer.txBlock(tx, protocol),
     })),
+    lifecycle: renderer.lifecycle(protocol),
   };
 }

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
@@ -1,10 +1,12 @@
 import {
   placeholderFor,
+  profileSuppliedNames,
   type SdkRenderer,
-  sortedProtocolParties,
-  tiiPath,
+  type SetupStep,
+  toPascalCase,
   toSnakeCase,
   type TrpConfig,
+  unboundParties,
   userProvidedParams,
 } from './shared';
 
@@ -16,75 +18,99 @@ function formatValue(value: unknown, type: string): string {
   return JSON.stringify(String(value));
 }
 
-function trpInit(trp: TrpConfig): string {
+function pythonModule(protocol: Protocol): string {
+  return `gen.python.${toSnakeCase(protocol.name)}`;
+}
+
+function clientOptionsLiteral(trp: TrpConfig): string {
   if (!trp.headers) {
-    return `    trp = TrpClient(endpoint=${JSON.stringify(trp.endpoint)})`;
+    return `ClientOptions(endpoint=${JSON.stringify(trp.endpoint)})`;
   }
-  const headersPyDict = '{'
+  const headers = '{'
     + Object.entries(trp.headers).map(([k, v]) => `${JSON.stringify(k)}: ${JSON.stringify(v)}`).join(', ')
     + '}';
-  return `    trp = TrpClient(endpoint=${JSON.stringify(trp.endpoint)}, headers=${headersPyDict})`;
+  return `ClientOptions(endpoint=${JSON.stringify(trp.endpoint)}, headers=${headers})`;
 }
 
-function setup(protocol: Protocol, profile: Profile | null, trp: TrpConfig, supplied: Set<string>): string {
-  const partyLines = sortedProtocolParties(protocol, supplied).map(p =>
-    `        .with_party(${JSON.stringify(p.name)}, Party.address(${JSON.stringify(p.address)}))`,
-  );
+function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string {
+  const module = pythonModule(protocol);
+  const hasProfiles = (protocol.profiles ?? []).length > 0;
+  const supplied = profileSuppliedNames(profile);
+  const unbound = unboundParties(protocol, supplied);
+  const profileArg = hasProfiles && profile
+    ? `, Profile.${toSnakeCase(profile.name).toUpperCase()}`
+    : '';
 
-  const clientLines = [
-    '    client = (',
-    '        Tx3Client(protocol, trp)',
-    ...(profile ? [`        .with_profile(${JSON.stringify(profile.name)})`] : []),
+  const partyLines = unbound.map((p, i) => {
+    const setter = `with_${toSnakeCase(p.name)}`;
+    if (i === 0) {
+      return `client = client.${setter}(Party.signer(signer))`;
+    }
+    return `client = client.${setter}(Party.address(${JSON.stringify(p.address)}))`;
+  });
+
+  return [
+    `from ${module} import Client${hasProfiles ? ', Profile' : ''}`,
+    'from tx3_sdk import Party',
+    'from tx3_sdk.signer import Ed25519Signer',
+    'from tx3_sdk.trp.client import ClientOptions',
+    '',
+    `signer = Ed25519Signer.from_hex("addr_test1...", "deadbeef...")`,
+    '',
+    `client = Client(${clientOptionsLiteral(trp)}${profileArg})`,
     ...partyLines,
-    '    )',
-  ];
-
-  return [
-    'import asyncio',
-    '',
-    'from tx3_sdk import CardanoSigner, Party, PollConfig, Protocol, TrpClient, Tx3Client',
-    '',
-    '',
-    'async def main() -> None:',
-    '    # 1) Load the protocol (compiled .tii file)',
-    `    protocol = Protocol.from_file(${JSON.stringify(tiiPath(protocol))})`,
-    '',
-    '    # 2) Connect to a TRP server',
-    trpInit(trp),
-    '',
-    '    # 3) Configure a signer (uncomment to enable .sign() / .submit())',
-    '    # signer = CardanoSigner.from_mnemonic(address="addr_test1...", phrase="word1 word2 ... word24")',
-    '',
-    `    # 4) Bind parties${profile ? ` and select the "${profile.name}" profile` : ''}`,
-    ...clientLines,
-    '',
-    '    # 5) Invoke one of the transactions listed below.',
-    '',
-    '    # 6) Once a signer is bound, chain .sign() / .submit() / .wait_for_confirmed():',
-    '    signed = await result.sign()',
-    '    submitted = await signed.submit()',
-    '    status = await submitted.wait_for_confirmed(PollConfig.default())',
-    '',
-    '',
-    'asyncio.run(main())',
   ].join('\n');
 }
 
-function txBlock(tx: Tx, protocol: Protocol, supplied: Set<string>): string {
+function txBlock(tx: Tx, protocol: Protocol): string {
+  const supplied = profileSuppliedNames(null);
+  const params = userProvidedParams(tx, protocol, supplied);
   const varName = toSnakeCase(tx.name);
-  const argLines = userProvidedParams(tx, protocol, supplied).map(param =>
-    `        .arg(${JSON.stringify(param.name)}, ${formatValue(placeholderFor(param.type), param.type)})`,
-  );
-  if (argLines.length === 0) {
-    return `${varName} = await client.tx(${JSON.stringify(tx.name)}).resolve()`;
+  const method = toSnakeCase(tx.name);
+  const paramsImport = `from ${pythonModule(protocol)} import ${toPascalCase(tx.name)}Params`;
+  const paramsType = `${toPascalCase(tx.name)}Params`;
+  if (params.length === 0) {
+    return [
+      paramsImport,
+      '',
+      `${varName} = await client.${method}(${paramsType}()).resolve()`,
+    ].join('\n');
   }
+  const argLines = params.map(param =>
+    `    ${toSnakeCase(param.name)}=${formatValue(placeholderFor(param.type), param.type)},`,
+  );
   return [
-    `${varName} = await (`,
-    `    client.tx(${JSON.stringify(tx.name)})`,
+    paramsImport,
+    '',
+    `${varName} = await client.${method}(${paramsType}(`,
     ...argLines,
-    '        .resolve()',
-    ')',
+    ')).resolve()',
   ].join('\n');
 }
 
-export const pythonRenderer: SdkRenderer = { lang: 'python', setup, txBlock };
+function lifecycle(_protocol: Protocol): string {
+  return [
+    'from tx3_sdk.facade import PollConfig',
+    '',
+    '# `resolved` is the result of one of the transactions above.',
+    'signed = await resolved.sign()',
+    'submitted = await signed.submit()',
+    'status = await submitted.wait_for_confirmed(PollConfig.default())',
+  ].join('\n');
+}
+
+const postCodegenInstall: SetupStep = {
+  kind: 'shell',
+  lang: 'bash',
+  title: 'Install the generated client\'s dependencies',
+  body: 'cd gen/python && pip install -r requirements.txt',
+  note: 'The generated requirements.txt pins tx3-sdk and its deps.',
+};
+
+export const pythonRenderer: SdkRenderer = {
+  lang: 'python',
+  postCodegenInstall,
+  quickStart,
+  txBlock,
+  lifecycle,
+};

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
@@ -1,28 +1,33 @@
 import {
   placeholderFor,
+  profileSuppliedNames,
   type SdkRenderer,
-  sortedProtocolParties,
-  tiiPath,
+  toPascalCase,
   toSnakeCase,
   type TrpConfig,
+  unboundParties,
   userProvidedParams,
 } from './shared';
 
-function formatValue(value: unknown): string {
-  if (typeof value === 'boolean') return `json!(${value})`;
-  if (typeof value === 'number') return `json!(${value})`;
-  if (typeof value === 'bigint') return `json!(${value})`;
-  return `json!(${JSON.stringify(String(value))})`;
+function formatValue(value: unknown, type: string): string {
+  if (typeof value === 'boolean') return String(value);
+  if (typeof value === 'number') return String(value);
+  if (typeof value === 'bigint') return String(value);
+  if (type.toLowerCase() === 'int' && typeof value === 'string' && /^-?\d+$/.test(value)) return value;
+  return `${JSON.stringify(String(value))}.to_string()`;
 }
 
-function trpInit(trp: TrpConfig): string[] {
-  const endpoint = `    endpoint: ${JSON.stringify(trp.endpoint)}.to_string(),`;
+function cratePath(protocol: Protocol): string {
+  return toSnakeCase(protocol.name);
+}
+
+function clientOptionsBlock(trp: TrpConfig): string[] {
   if (!trp.headers) {
     return [
-      'let trp = Client::new(ClientOptions {',
-      endpoint,
+      'let options = ClientOptions {',
+      `    endpoint: ${JSON.stringify(trp.endpoint)}.to_string(),`,
       '    headers: None,',
-      '});',
+      '};',
     ];
   }
   const headerInserts = Object.entries(trp.headers).map(([k, v]) =>
@@ -31,66 +36,85 @@ function trpInit(trp: TrpConfig): string[] {
   return [
     'let mut headers = std::collections::HashMap::new();',
     ...headerInserts,
-    'let trp = Client::new(ClientOptions {',
-    endpoint,
+    'let options = ClientOptions {',
+    `    endpoint: ${JSON.stringify(trp.endpoint)}.to_string(),`,
     '    headers: Some(headers),',
-    '});',
+    '};',
   ];
 }
 
-function setup(protocol: Protocol, profile: Profile | null, trp: TrpConfig, supplied: Set<string>): string {
-  const partyLines = sortedProtocolParties(protocol, supplied).map(p =>
-    `    .with_party(${JSON.stringify(p.name)}, Party::address(${JSON.stringify(p.address)}))`,
-  );
+function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string {
+  const crate = cratePath(protocol);
+  const hasProfiles = (protocol.profiles ?? []).length > 0;
+  const supplied = profileSuppliedNames(profile);
+  const unbound = unboundParties(protocol, supplied);
+  const profileArg = hasProfiles && profile
+    ? `, ${crate}::Profile::${toPascalCase(profile.name)}`
+    : '';
 
-  const clientLines = [
-    'let tx3 = Tx3Client::new(protocol, trp)',
-    ...(profile ? [`    .with_profile(${JSON.stringify(profile.name)})`] : []),
-    ...partyLines,
+  const partyLines = unbound.map((p, i) => {
+    const setter = `with_${toSnakeCase(p.name)}`;
+    if (i === 0) {
+      return `    .${setter}(Party::signer(signer))`;
+    }
+    return `    .${setter}(Party::address(${JSON.stringify(p.address)}))`;
+  });
+
+  const lines: string[] = [
+    `use ${crate}::Client;`,
+    'use tx3_sdk::Party;',
+    'use tx3_sdk::signer::Ed25519Signer;',
+    'use tx3_sdk::trp::ClientOptions;',
+    '',
+    ...clientOptionsBlock(trp),
+    '',
+    'let signer = Ed25519Signer::from_hex("addr_test1...", "deadbeef...")?;',
+    '',
   ];
-  clientLines[clientLines.length - 1] += ';';
+  if (partyLines.length === 0) {
+    lines.push(`let client = Client::new(options${profileArg});`);
+  } else {
+    lines.push(`let client = Client::new(options${profileArg})`);
+    lines.push(...partyLines);
+    lines[lines.length - 1] += ';';
+  }
+  return lines.join('\n');
+}
 
+function txBlock(tx: Tx, protocol: Protocol): string {
+  const supplied = profileSuppliedNames(null);
+  const params = userProvidedParams(tx, protocol, supplied);
+  const varName = toSnakeCase(tx.name);
+  const method = toSnakeCase(tx.name);
+  const paramsType = `${cratePath(protocol)}::${toPascalCase(tx.name)}Params`;
+  if (params.length === 0) {
+    return `let ${varName} = client.${method}(${paramsType} {}).resolve().await?;`;
+  }
+  const argLines = params.map(param =>
+    `    ${toSnakeCase(param.name)}: ${formatValue(placeholderFor(param.type), param.type)},`,
+  );
   return [
-    'use serde_json::json;',
-    'use tx3_sdk::trp::{Client, ClientOptions};',
-    'use tx3_sdk::{CardanoSigner, Party, PollConfig, Tx3Client};',
+    `let ${varName} = client.${method}(${paramsType} {`,
+    ...argLines,
+    '}).resolve().await?;',
+  ].join('\n');
+}
+
+function lifecycle(_protocol: Protocol): string {
+  return [
+    'use tx3_sdk::facade::PollConfig;',
     '',
-    '// 1. Load the protocol (compiled .tii file)',
-    `let protocol = tx3_sdk::tii::Protocol::from_file(${JSON.stringify(tiiPath(protocol))})?;`,
-    '',
-    '// 2. Connect to a TRP server',
-    ...trpInit(trp),
-    '',
-    '// 3. Configure a signer (uncomment to enable .sign() / .submit())',
-    '// let signer = CardanoSigner::from_mnemonic("addr_test1...", "word1 word2 ... word24")?;',
-    '',
-    `// 4. Bind parties${profile ? ` and select the "${profile.name}" profile` : ''}`,
-    ...clientLines,
-    '',
-    '// 5. Invoke one of the transactions listed below.',
-    '',
-    '// 6. Once a signer is bound, chain .sign() / .submit() / .wait_for_confirmed():',
-    'let signed = result.sign()?;',
+    '// `resolved` is the result of one of the transactions above.',
+    'let signed = resolved.sign()?;',
     'let submitted = signed.submit().await?;',
     'let status = submitted.wait_for_confirmed(PollConfig::default()).await?;',
   ].join('\n');
 }
 
-function txBlock(tx: Tx, protocol: Protocol, supplied: Set<string>): string {
-  const varName = toSnakeCase(tx.name);
-  const argLines = userProvidedParams(tx, protocol, supplied).map(param =>
-    `    .arg(${JSON.stringify(param.name)}, ${formatValue(placeholderFor(param.type))})`,
-  );
-  if (argLines.length === 0) {
-    return `let ${varName} = tx3.tx(${JSON.stringify(tx.name)}).resolve().await?;`;
-  }
-  return [
-    `let ${varName} = tx3`,
-    `    .tx(${JSON.stringify(tx.name)})`,
-    ...argLines,
-    '    .resolve()',
-    '    .await?;',
-  ].join('\n');
-}
-
-export const rustRenderer: SdkRenderer = { lang: 'rust', setup, txBlock };
+export const rustRenderer: SdkRenderer = {
+  lang: 'rust',
+  postCodegenInstall: null,
+  quickStart,
+  txBlock,
+  lifecycle,
+};

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -18,32 +18,53 @@ export interface QuickStartTx {
   code: string;
 }
 
+export interface SetupStep {
+  // `kind` describes intent for the reader; `lang` drives syntax highlighting.
+  kind: 'shell' | 'toml';
+  lang: SupportedLanguages;
+  title: string;
+  body: string;
+  note?: string;
+}
+
 export interface QuickStartSnippet {
   lang: SupportedLanguages;
-  setup: string;
+  setupSteps: SetupStep[];
+  quickStart: string;
   transactions: QuickStartTx[];
+  lifecycle: string;
 }
+
+// Plug a new SDK in by implementing this and registering it in `index.ts`.
+export interface SdkRenderer {
+  lang: SupportedLanguages;
+  // Optional follow-up after `trix codegen` to install the dependencies of the
+  // generated client (the codegen output declares its SDK dep — Cargo picks it
+  // up on build, so Rust doesn't need this; npm/pip/go need an explicit step).
+  postCodegenInstall: SetupStep | null;
+  quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string;
+  txBlock(tx: Tx, protocol: Protocol): string;
+  // The sign + submit chain that takes any resolved tx from `txBlock` and pushes
+  // it to the chain. The example uses `tx` as the variable name.
+  lifecycle(protocol: Protocol): string;
+}
+
+export const byName = <T extends { name: string; }>(a: T, b: T) => a.name.localeCompare(b.name);
+
+export const PARTY_ADDRESS_PLACEHOLDER = 'addr_test1...';
 
 export interface PartyBinding {
   name: string;
   address: string;
 }
 
-// Plug a new SDK in by implementing this and registering it in `index.ts`.
-export interface SdkRenderer {
-  lang: SupportedLanguages;
-  setup(protocol: Protocol, profile: Profile | null, trp: TrpConfig, supplied: Set<string>): string;
-  txBlock(tx: Tx, protocol: Protocol, supplied: Set<string>): string;
-}
-
-export const PARTY_ADDRESS_PLACEHOLDER = 'addr_test1...';
-
-export const byName = <T extends { name: string; }>(a: T, b: T) => a.name.localeCompare(b.name);
-
-// Path where `trix add {scope}/{name}` writes the compiled .tii, which each
-// SDK then loads via Protocol.fromFile.
-export function tiiPath(protocol: Protocol): string {
-  return `./.tx3/tii/${protocol.scope}/${protocol.name}.tii`;
+// Parties declared by the protocol that the profile does NOT supply — these
+// need a `.with<Name>(...)` call on the generated Client.
+export function unboundParties(protocol: Protocol, supplied: Set<string>): PartyBinding[] {
+  return [...(protocol.parties ?? [])]
+    .filter(p => !supplied.has(p.name))
+    .sort(byName)
+    .map(p => ({ name: p.name, address: PARTY_ADDRESS_PLACEHOLDER }));
 }
 
 export function toCamelCase(name: string): string {
@@ -56,9 +77,14 @@ export function toSnakeCase(name: string): string {
   return name.split(/[^A-Za-z0-9]+/).filter(Boolean).map(p => p.toLowerCase()).join('_') || 'result';
 }
 
-// Names supplied by the profile — either bound directly via `profile.parties`
-// or declared as keys in the `profile.environment` JSON. The SDK applies these
-// at runtime through `.withProfile()`, so the snippet skips them.
+export function toPascalCase(name: string): string {
+  const c = toCamelCase(name);
+  return c[0] ? c[0].toUpperCase() + c.slice(1) : c;
+}
+
+// Names supplied by the active profile — parties bound on the profile and any
+// keys declared in the profile env. These are baked into the generated client
+// at codegen time, so `txBlock` filters them out of the user-facing args.
 export function profileSuppliedNames(profile: Profile | null): Set<string> {
   const names = new Set<string>();
   if (!profile) return names;
@@ -73,19 +99,8 @@ export function profileSuppliedNames(profile: Profile | null): Set<string> {
   return names;
 }
 
-// All parties declared by the protocol, sorted by name. Addresses are always
-// placeholders so the snippet doesn't leak profile-specific values. Parties
-// already supplied by the profile (via parties or env) are omitted.
-export function sortedProtocolParties(protocol: Protocol, supplied: Set<string>): PartyBinding[] {
-  return [...(protocol.parties ?? [])]
-    .filter(p => !supplied.has(p.name))
-    .sort(byName)
-    .map(p => ({ name: p.name, address: PARTY_ADDRESS_PLACEHOLDER }));
-}
-
-// Tx params that should surface as `.arg(...)` — everything except names that
-// are already bound at the client level via `.withParty` or supplied by the
-// profile.
+// Tx params that should surface as user-provided args — everything except party
+// names declared by the protocol and names already supplied by the profile.
 export function userProvidedParams(tx: Tx, protocol: Protocol, supplied: Set<string>): TxParam[] {
   const partyNames = new Set((protocol.parties ?? []).map(p => p.name));
   return tx.parameters
@@ -101,4 +116,78 @@ export function placeholderFor(type: string): unknown {
   if (t.includes('bytes') || t.includes('hash')) return '0011223344';
   if (t.includes('utxo')) return 'tx_hash#0';
   return '...';
+}
+
+// Codegen plugin name per language target (matches `[[codegen]]` plugin keys
+// recognized by `trix codegen`).
+const CODEGEN_PLUGIN: Record<SDKKey, string> = {
+  typescript: 'ts-client',
+  rust: 'rust-client',
+  go: 'go-client',
+  python: 'python-client',
+};
+
+const OUTPUT_DIR: Record<SDKKey, string> = {
+  typescript: './gen/typescript',
+  rust: './gen/rust',
+  go: './gen/go',
+  python: './gen/python',
+};
+
+export function bindingPlugin(lang: SDKKey): string {
+  return CODEGEN_PLUGIN[lang];
+}
+
+export function bindingsTomlBlock(lang: SDKKey): string {
+  return [
+    '[[codegen]]',
+    `plugin = ${JSON.stringify(CODEGEN_PLUGIN[lang])}`,
+    `output_dir = ${JSON.stringify(OUTPUT_DIR[lang])}`,
+  ].join('\n');
+}
+
+export function outputDir(lang: SDKKey): string {
+  return OUTPUT_DIR[lang];
+}
+
+// Shared install-flow steps. Each renderer prepends its own SDK install step.
+export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] {
+  const ref = `${protocol.scope}/${protocol.name}@${protocol.version}`;
+  return [
+    {
+      kind: 'shell',
+      lang: 'bash',
+      title: 'Install the Tx3 toolchain',
+      body: 'brew install txpipe/tap/tx3up && tx3up',
+      note: 'Skip if `trix` is already on your PATH. See https://docs.txpipe.io/tx3/installation for other platforms.',
+    },
+    {
+      kind: 'shell',
+      lang: 'bash',
+      title: 'Initialize a trix project',
+      body: 'trix init',
+      note: 'Skip this step if you already have a trix project.',
+    },
+    {
+      kind: 'shell',
+      lang: 'bash',
+      title: 'Install the protocol',
+      body: `trix use ${ref}`,
+      note: 'Downloads the compiled .tii into your trix project and registers it as a dependency.',
+    },
+    {
+      kind: 'toml',
+      lang: 'toml',
+      title: 'Configure codegen',
+      body: bindingsTomlBlock(lang),
+      note: 'Add this entry to trix.toml so trix knows which language to generate.',
+    },
+    {
+      kind: 'shell',
+      lang: 'bash',
+      title: 'Generate the client',
+      body: 'trix codegen',
+      note: `Writes the typed client to ${OUTPUT_DIR[lang]}.`,
+    },
+  ];
 }

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
@@ -1,10 +1,12 @@
 import {
   placeholderFor,
+  profileSuppliedNames,
   type SdkRenderer,
-  sortedProtocolParties,
-  tiiPath,
+  type SetupStep,
   toCamelCase,
+  toPascalCase,
   type TrpConfig,
+  unboundParties,
   userProvidedParams,
 } from './shared';
 
@@ -17,72 +19,93 @@ function formatValue(value: unknown, type: string): string {
   return JSON.stringify(String(value));
 }
 
-function trpInit(trp: TrpConfig): string[] {
-  const headersLine = trp.headers
-    ? `  headers: ${JSON.stringify(trp.headers)},`
-    : null;
-  if (!headersLine) {
-    return [`const trp = new TrpClient({ endpoint: ${JSON.stringify(trp.endpoint)} });`];
+function clientOptionsLiteral(trp: TrpConfig): string {
+  if (!trp.headers) {
+    return `{ endpoint: ${JSON.stringify(trp.endpoint)} }`;
   }
+  const headers = Object.entries(trp.headers)
+    .map(([k, v]) => `${JSON.stringify(k)}: ${JSON.stringify(v)}`)
+    .join(', ');
   return [
-    'const trp = new TrpClient({',
+    '{',
     `  endpoint: ${JSON.stringify(trp.endpoint)},`,
-    headersLine,
-    '});',
-  ];
-}
-
-function setup(protocol: Protocol, profile: Profile | null, trp: TrpConfig, supplied: Set<string>): string {
-  const partyLines = sortedProtocolParties(protocol, supplied).map(p =>
-    `  .withParty(${JSON.stringify(p.name)}, Party.address(${JSON.stringify(p.address)}))`,
-  );
-
-  const clientLines = [
-    'const tx3 = new Tx3Client(protocol, trp)',
-    ...(profile ? [`  .withProfile(${JSON.stringify(profile.name)})`] : []),
-    ...partyLines,
-  ];
-  clientLines[clientLines.length - 1] += ';';
-
-  return [
-    'import { Tx3Client, Protocol, TrpClient, Party, Ed25519Signer, PollConfig } from "tx3-sdk";',
-    '',
-    '// 1. Load the protocol (compiled .tii file)',
-    `const protocol = await Protocol.fromFile(${JSON.stringify(tiiPath(protocol))});`,
-    '',
-    '// 2. Connect to a TRP server',
-    ...trpInit(trp),
-    '',
-    '// 3. Configure a signer (uncomment to enable .sign() / .submit())',
-    '// const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");',
-    '',
-    `// 4. Bind parties${profile ? ` and select the "${profile.name}" profile` : ''}`,
-    ...clientLines,
-    '',
-    '// 5. Invoke one of the transactions listed below.',
-    '',
-    '// 6. Once a signer is bound, chain .sign() / .submit() / .waitForConfirmed():',
-    'const status = await result',
-    '  .sign()',
-    '  .then(s => s.submit())',
-    '  .then(sub => sub.waitForConfirmed(PollConfig.default()));',
+    `  headers: { ${headers} },`,
+    '}',
   ].join('\n');
 }
 
-function txBlock(tx: Tx, protocol: Protocol, supplied: Set<string>): string {
-  const varName = toCamelCase(tx.name);
-  const argLines = userProvidedParams(tx, protocol, supplied).map(param =>
-    `  .arg(${JSON.stringify(param.name)}, ${formatValue(placeholderFor(param.type), param.type)})`,
-  );
-  if (argLines.length === 0) {
-    return `const ${varName} = await tx3.tx(${JSON.stringify(tx.name)}).resolve();`;
+function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string {
+  const hasProfiles = (protocol.profiles ?? []).length > 0;
+  const supplied = profileSuppliedNames(profile);
+  const unbound = unboundParties(protocol, supplied);
+  const profileArg = hasProfiles && profile ? `, ${JSON.stringify(profile.name)}` : '';
+
+  const partyLines = unbound.map((p, i) => {
+    const setter = `with${toPascalCase(p.name)}`;
+    if (i === 0) {
+      return `  .${setter}(Party.signer(signer))`;
+    }
+    return `  .${setter}(Party.address(${JSON.stringify(p.address)}))`;
+  });
+
+  const lines: string[] = [
+    `import { Client } from "./gen/typescript/${protocol.name}";`,
+    'import { Ed25519Signer, Party } from "tx3-sdk";',
+    '',
+    'const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");',
+    '',
+  ];
+  if (partyLines.length === 0) {
+    lines.push(`const client = new Client(${clientOptionsLiteral(trp)}${profileArg});`);
+  } else {
+    lines.push(`const client = new Client(${clientOptionsLiteral(trp)}${profileArg})`);
+    lines.push(...partyLines);
+    lines[lines.length - 1] += ';';
   }
+  return lines.join('\n');
+}
+
+function txBlock(tx: Tx, protocol: Protocol): string {
+  const supplied = profileSuppliedNames(null);
+  const params = userProvidedParams(tx, protocol, supplied);
+  const varName = toCamelCase(tx.name);
+  const method = toCamelCase(tx.name);
+  if (params.length === 0) {
+    return `const ${varName} = await client.${method}({}).resolve();`;
+  }
+  const argLines = params.map(param =>
+    `  ${toCamelCase(param.name)}: ${formatValue(placeholderFor(param.type), param.type)},`,
+  );
   return [
-    `const ${varName} = await tx3`,
-    `  .tx(${JSON.stringify(tx.name)})`,
+    `const ${varName} = await client.${method}({`,
     ...argLines,
-    '  .resolve();',
+    '}).resolve();',
   ].join('\n');
 }
 
-export const typescriptRenderer: SdkRenderer = { lang: 'typescript', setup, txBlock };
+function lifecycle(_protocol: Protocol): string {
+  return [
+    'import { PollConfig } from "tx3-sdk";',
+    '',
+    '// `resolved` is the result of one of the transactions above.',
+    'const signed = await resolved.sign();',
+    'const submitted = await signed.submit();',
+    'const status = await submitted.waitForConfirmed(PollConfig.default());',
+  ].join('\n');
+}
+
+const postCodegenInstall: SetupStep = {
+  kind: 'shell',
+  lang: 'bash',
+  title: 'Install the generated client\'s dependencies',
+  body: 'cd gen/typescript && npm install',
+  note: 'The generated package.json declares tx3-sdk as a dependency.',
+};
+
+export const typescriptRenderer: SdkRenderer = {
+  lang: 'typescript',
+  postCodegenInstall,
+  quickStart,
+  txBlock,
+  lifecycle,
+};


### PR DESCRIPTION
## Summary
- Replace the dynamic-flow snippets (`Protocol.fromFile` + manual `Tx3Client` wiring) on the protocol-detail SDKs tab with codegen-flow snippets that walk the user through `trix use <scope>/<name>@<ver>`, a `[[codegen]]` entry, and `trix codegen`.
- Each language snippet now imports the generated `Client` from `./gen/<lang>/<name>`, constructs it with `ClientOptions` (from the TRP dropdown) plus the selected `Profile`, binds unbound parties via per-party setters (first one as `Party.signer(signer)`, rest as `Party.address(...)`), and resolves transactions through the typed per-tx methods.
- New **Sign and submit** section rendered after the transactions list, with the canonical `resolved.sign() → submitted.submit() → waitForConfirmed(PollConfig.default())` chain per SDK.
- `InstallSection` becomes a numbered setup checklist: install the Tx3 toolchain → `trix init` → `trix use` → `[[codegen]]` toml → `trix codegen` → optional post-codegen `npm install` / `go mod tidy` / `pip install -r requirements.txt` (Rust skipped — cargo resolves on build).

## Test plan
- [ ] `npm run typecheck` (passes locally)
- [ ] `npm run dev` and visit a protocol detail page → SDKs tab
- [ ] Cycle TypeScript / Rust / Go / Python tabs — setup steps render in order, codegen plugin name matches the language
- [ ] Cycle the profile dropdown — `trix use` ref, `Profile` constructor arg, and `unbound` party setters update accordingly
- [ ] Cycle the TRP dropdown (Local / Demeter) — endpoint and headers inline correctly into the generated `Client` ctor
- [ ] Inspect a tx with args and one without — `txBlock` shapes look right and end in `.resolve()`
- [ ] Sign and submit section shows the lifecycle chain in the active language

🤖 Generated with [Claude Code](https://claude.com/claude-code)