### PR TITLE
feat: render protocol logos in catalogue and detail header

### DIFF
--- a/frontend/app/components/ProtocolLogo.tsx
+++ b/frontend/app/components/ProtocolLogo.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import clsx from 'clsx';
+
+interface ProtocolLogoProps {
+  scope: string;
+  name: string;
+  size: 'sm' | 'lg';
+  className?: string;
+}
+
+const SIZE_CLASSES: Record<ProtocolLogoProps['size'], string> = {
+  sm: 'w-10 h-10 text-base',
+  lg: 'w-16 h-16 text-2xl',
+};
+
+function initialsFor(scope: string, name: string): string {
+  const head = (name || scope || '?').trim();
+  return head.slice(0, 2).toUpperCase();
+}
+
+// Renders the protocol logo by hitting the same-origin
+// `/api/protocols/:scope/:name/logo` resource route. The backend serves PNG
+// bytes from the OCI artifact or 404 when no logo layer was attached at
+// publish time. On any non-OK response we fall back to a placeholder so the
+// card layout is stable whether or not the publisher shipped a logo.
+export function ProtocolLogo({ scope, name, size, className }: ProtocolLogoProps) {
+  const [failed, setFailed] = useState(false);
+
+  const wrapper = clsx(
+    SIZE_CLASSES[size],
+    'shrink-0 rounded-md bg-woodsmoke-900 border border-zinc-800 overflow-hidden flex items-center justify-center',
+    className,
+  );
+
+  if (failed) {
+    return (
+      <div className={wrapper}>
+        <span className="font-semibold text-zinc-400">{initialsFor(scope, name)}</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className={wrapper}>
+      <img
+        src={`/api/protocols/${encodeURIComponent(scope)}/${encodeURIComponent(name)}/logo`}
+        alt=""
+        className="w-full h-full object-cover"
+        onError={() => setFailed(true)}
+        loading="lazy"
+        decoding="async"
+      />
+    </div>
+  );
+}

--- a/frontend/app/pages/home/catalogue.tsx
+++ b/frontend/app/pages/home/catalogue.tsx
@@ -1,5 +1,6 @@
 import { Link, useSearchParams } from 'react-router';
 import clsx from 'clsx';
+import { ProtocolLogo } from '~/components/ProtocolLogo';
 import { Button } from '~/components/ui/Button';
 import { ChevronLeftIcon } from '~/components/icons/chevron-left';
 import { ChevronRightIcon } from '~/components/icons/chevron-right';
@@ -14,11 +15,14 @@ interface CatalogueProps {
 function PackageCard({ protocol }: { protocol: Protocol; }) {
   return (
     <Link to={`/protocol/${protocol.scope}/${protocol.name}`}>
-      <div className="py-6 px-8 border border-zinc-900 bg-woodsmoke-950 rounded-lg">
-        <h3 className="text-lg font-semibold">{protocol.name}</h3>
-        <div className="mt-2">
-          <span className="text-primary-600">@{protocol.scope}</span>
-          <span className="text-zinc-400"> • v{protocol.version}</span>
+      <div className="py-6 px-8 border border-zinc-900 bg-woodsmoke-950 rounded-lg flex items-center gap-4">
+        <ProtocolLogo scope={protocol.scope} name={protocol.name} size="sm" />
+        <div className="min-w-0">
+          <h3 className="text-lg font-semibold truncate">{protocol.name}</h3>
+          <div className="mt-2">
+            <span className="text-primary-600">@{protocol.scope}</span>
+            <span className="text-zinc-400"> • v{protocol.version}</span>
+          </div>
         </div>
       </div>
     </Link>

--- a/frontend/app/pages/protocol/details/index.tsx
+++ b/frontend/app/pages/protocol/details/index.tsx
@@ -6,6 +6,7 @@ import { TabName } from '~/components/TabName';
 import { SearchBar } from '~/components/SearchBar';
 import { ToTopButton } from '~/components/ToTopButton';
 import { Header } from '~/components/Header';
+import { ProtocolLogo } from '~/components/ProtocolLogo';
 
 // Icons
 import { ArrowLeftIcon } from '~/components/icons/arrow-left';
@@ -54,11 +55,14 @@ export function ProtocolDetails({ protocol, rpcDocsUrl }: ProtocolDetailsProps) 
       />
       <main className="mt-8 flex flex-col flex-1">
         <div className="container relative after:content-[''] after:absolute after:w-[719px] after:h-[559.95px] after:bg-[radial-gradient(ellipse_359px_280px_at_center,#5A5BED_0%,rgba(37,45,71,0)_100%)] after:-right-[223px] after:-top-12.5 after:-z-1 after:opacity-15">
-          <div className="border-l-[7px] border-zinc-800 rounded-sm pl-4">
-            <h1 className="text-3xl font-semibold">{protocol.name}</h1>
-            <div className="mt-2">
-              <h2 className="inline text-primary-600">@{protocol.scope}</h2>
-              <span className="opacity-50"> • v{protocol.version}</span>
+          <div className="flex items-center gap-4">
+            <ProtocolLogo scope={protocol.scope} name={protocol.name} size="lg" />
+            <div className="border-l-[7px] border-zinc-800 rounded-sm pl-4">
+              <h1 className="text-3xl font-semibold">{protocol.name}</h1>
+              <div className="mt-2">
+                <h2 className="inline text-primary-600">@{protocol.scope}</h2>
+                <span className="opacity-50"> • v{protocol.version}</span>
+              </div>
             </div>
           </div>
 

--- a/frontend/app/routes/api.protocols.$scope.$name.logo.tsx
+++ b/frontend/app/routes/api.protocols.$scope.$name.logo.tsx
@@ -1,0 +1,19 @@
+import type { Route } from './+types/api.protocols.$scope.$name.logo';
+
+export async function loader({ params }: Route.LoaderArgs) {
+  const { scope, name } = params;
+  const upstream = `${process.env.API_ENDPOINT}/protocols/${encodeURIComponent(scope)}/${encodeURIComponent(name)}/logo`;
+
+  const res = await fetch(upstream);
+  if (!res.ok) {
+    return new Response(null, { status: res.status });
+  }
+
+  return new Response(res.body, {
+    status: 200,
+    headers: {
+      'Content-Type': res.headers.get('Content-Type') ?? 'image/png',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- New `ProtocolLogo` component renders the logo via a same-origin resource route, with an initials placeholder fallback on any non-OK response. Stable layout whether or not the publisher shipped a logo.
- New `app/routes/api.protocols.$scope.$name.logo.tsx` server-side resource route proxies the backend's `/protocols/<scope>/<name>/logo` endpoint (no new browser env var, no CORS).
- Logo rendered at 40×40 in the catalogue card and 64×64 in the protocol detail header.

Pairs with the backend endpoint in #17 and the publish-side change in [trix#115](https://github.com/tx3-lang/trix/pull/115). Until both ship the resource route returns 404 for every protocol and the placeholder is what users see — safe to land independently.

## Test plan

- [ ] `pnpm typecheck` clean (verified locally)
- [ ] With backend deployed and a protocol carrying a logo: catalogue card and detail header show the image
- [ ] Protocol without a logo: placeholder renders with initials, layout unchanged
- [ ] Backend unavailable / route 502: placeholder still renders, no console errors blocking the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)