### PR TITLE
fix: include Name in newest_tag zot projection

### DIFF
--- a/backend/src/oci.rs
+++ b/backend/src/oci.rs
@@ -113,7 +113,7 @@ fn get_client() -> Client {
 pub async fn newest_tag(repo: &str) -> Result<Option<String>, Box<dyn std::error::Error + Send + Sync>> {
     let registry_api = get_registry_api_url();
     let query = format!(
-        r#"query ExpandedRepoInfo {{ ExpandedRepoInfo(repo: "{}") {{ Summary {{ NewestImage {{ Tag }} }} Images {{ Tag }} }} }}"#,
+        r#"query ExpandedRepoInfo {{ ExpandedRepoInfo(repo: "{}") {{ Summary {{ Name NewestImage {{ Tag }} }} Images {{ Tag }} }} }}"#,
         repo
     );
     let url = format!("{}/_zot/ext/search?query={}", registry_api, urlencoding::encode(&query));


### PR DESCRIPTION
## Summary

The new `/protocols/<scope>/<name>/logo` route (#17) returned 502 for every protocol in the live registry. Root cause: `newest_tag`'s GraphQL projection against zot omitted the `Name` field on `Summary`, but the local `RepoSummary` struct has `name: String` (non-optional). The deserialize failed, the handler caught it as `Err(_)`, and Rocket served a 502.

The fix matches what the existing detail-query path in `query.rs` already does: include `Name` in the `Summary` projection.

Verified locally against `oci.tx3.land` — `newest_tag("open-tx3/hydra-heads")` now returns `Some("0.0.0")` and `get_logo_png` finds the 24581-byte PNG layer.

## Test plan

- [ ] After deploy: `curl -I https://api.tx3.land/protocols/open-tx3/hydra-heads/logo` returns `200 image/png`
- [ ] `https://tx3.land/protocol/open-tx3/hydra-heads` renders the logo
- [ ] Logo-less protocols still return 404, not 502

🤖 Generated with [Claude Code](https://claude.com/claude-code)