### PR TITLE
feat: surface TII descriptions in protocol resolvers

### DIFF
--- a/backend/src/schema/protocol/mod.rs
+++ b/backend/src/schema/protocol/mod.rs
@@ -25,6 +25,8 @@ pub struct TiiFile {
 pub struct TiiTransaction {
     pub tir: TiiTirEnvelope,
     pub description: Option<String>,
+    #[serde(default)]
+    pub params: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -197,9 +199,13 @@ impl Protocol {
                 })
                 .unwrap_or_else(|| "unknown".to_string());
 
+            let description = schema.get("description")
+                .and_then(|d| d.as_str())
+                .map(String::from);
+
             EnvironmentParam {
                 name: name.clone(),
-                description: None,
+                description,
                 r#type,
             }
         }).collect()
@@ -231,9 +237,37 @@ impl Protocol {
         parameters
     }
 
+    /// Pulls per-property `description` values out of a JSON Schema object
+    /// shaped like `{ "properties": { "<name>": { "description": "..." } } }`.
+    fn descriptions_from_params_schema(
+        params: Option<&serde_json::Value>,
+    ) -> HashMap<String, String> {
+        params
+            .and_then(|p| p.get("properties"))
+            .and_then(|p| p.as_object())
+            .map(|props| {
+                props
+                    .iter()
+                    .filter_map(|(name, schema)| {
+                        schema
+                            .get("description")
+                            .and_then(|d| d.as_str())
+                            .map(|d| (name.clone(), d.to_string()))
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
     fn transactions_from_tii(&self, tii_file: &TiiFile) -> Vec<Tx> {
         tii_file.transactions.iter().map(|(name, tx)| {
-            let parameters = Self::extract_params_from_tir(&tx.tir);
+            let descriptions = Self::descriptions_from_params_schema(tx.params.as_ref());
+            let mut parameters = Self::extract_params_from_tir(&tx.tir);
+            for param in &mut parameters {
+                if let Some(desc) = descriptions.get(&param.name) {
+                    param.description = Some(desc.clone());
+                }
+            }
             let inputs = Self::extract_inputs_from_tir(&tx.tir);
             let outputs = Self::extract_outputs_from_tir(&tx.tir);
 


### PR DESCRIPTION
## Summary
- `EnvironmentParam.description` now reads from each env property's JSON Schema `description` key instead of returning `None`.
- `TxParam.description` is overlaid onto the TIR-derived param list from the transaction's `params` JSON Schema, via a new `descriptions_from_params_schema` helper.
- `TiiTransaction` deserializes the optional `params` schema so we can reach those per-property descriptions.
- `Party.description`, `Tx.description`, and `Profile.description` already forwarded TII values — no change there.

## Why
The frontend's protocol tab already renders a Description column for parties, env vars, txs, and tx params, but those columns were always empty because the resolvers ignored the description fields published in TII. Paired with [tx3-lang/tx3#329](https://github.com/tx3-lang/tx3/pull/329), which makes tx3c populate those TII fields from source `///` doc-comments, this PR completes the pipe end to end with zero frontend changes.

## Test plan
- [x] `cargo build -p tx3-registry-backend` passes.
- [ ] Hit `protocol(scope, name)` over GraphQL against a registry serving a TII with descriptions (waiting on a republished protocol once tx3-lang/tx3#329 lands and tx3-lang gets a release) and confirm `environment[].description`, `transactions[].description`, and `transactions[].parameters[].description` are populated.
- [ ] Load the protocol detail page in the registry frontend — the existing JSX (`registry/frontend/app/pages/protocol/details/tab/protocol.tsx`) already binds these fields, so no frontend change should be needed.

## Compatibility notes
- The `descriptions_from_params_schema` helper is a no-op when `params` is absent or malformed; protocols still on older TII without descriptions continue to render `—`.
- The source-path fallback (`extract_params`/`transactions_from_source`) still returns `description: None`. Lifting that requires upgrading the `tx3-lang` crates.io dep to a release that includes the new AST `docstring` field; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)