### PR TITLE
feat(frontend): responsive layout + protocol description on cards

### DIFF
--- a/frontend/app/app.css
+++ b/frontend/app/app.css
@@ -37,7 +37,7 @@
 
 /* Utilities */
 @utility container {
-  @apply px-20 mx-auto 2xl:max-w-[1440px] xl:max-w-[1440px];
+  @apply px-4 sm:px-8 lg:px-20 mx-auto 2xl:max-w-[1440px] xl:max-w-[1440px];
 }
 
 @utility prose-tx3 {

--- a/frontend/app/components/Hero.tsx
+++ b/frontend/app/components/Hero.tsx
@@ -8,8 +8,8 @@ interface Props {
 
 export function Hero({ className, onSearch }: Props) {
   return (
-    <section className={clsx(className)}>
-      <h1 className="text-4xl font-bold text-center tracking-wide ">Registry for UTxO Protocols</h1>
+    <section className={clsx('px-4 sm:px-8', className)}>
+      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center tracking-wide">Registry for UTxO Protocols</h1>
       <SearchBar className="mt-8 mx-auto max-w-[836px]" onSearch={onSearch} />
     </section>
   );

--- a/frontend/app/components/TabName.tsx
+++ b/frontend/app/components/TabName.tsx
@@ -12,7 +12,7 @@ export function TabName({ icon, name, onClick, active }: TabProps) {
     <button
       data-active={active}
       type="button"
-      className="flex items-center px-3 py-2 gap-2 text-zinc-500 data-[active=true]:text-zinc-50 cursor-pointer transition-colors duration-300 hover:text-zinc-300"
+      className="flex shrink-0 items-center px-3 py-2 gap-2 text-zinc-500 data-[active=true]:text-zinc-50 cursor-pointer transition-colors duration-300 hover:text-zinc-300 whitespace-nowrap"
       onClick={onClick}
     >
       {icon}

--- a/frontend/app/gql/protocols.query.ts
+++ b/frontend/app/gql/protocols.query.ts
@@ -15,6 +15,7 @@ export const LIST_QUERY = gql`
         name
         scope
         version
+        description
       }
       pageInfo {
         hasPreviousPage

--- a/frontend/app/pages/home/catalogue.tsx
+++ b/frontend/app/pages/home/catalogue.tsx
@@ -15,15 +15,22 @@ interface CatalogueProps {
 function PackageCard({ protocol }: { protocol: Protocol; }) {
   return (
     <Link to={`/protocol/${protocol.scope}/${protocol.name}`}>
-      <div className="py-6 px-8 border border-zinc-900 bg-woodsmoke-950 rounded-lg flex items-center gap-4">
-        <ProtocolLogo scope={protocol.scope} name={protocol.name} size="sm" />
-        <div className="min-w-0">
-          <h3 className="text-lg font-semibold truncate">{protocol.name}</h3>
-          <div className="mt-2">
-            <span className="text-primary-600">@{protocol.scope}</span>
-            <span className="text-zinc-400"> • v{protocol.version}</span>
+      <div className="h-full py-5 px-5 sm:py-6 sm:px-8 border border-zinc-900 bg-woodsmoke-950 rounded-lg flex flex-col gap-3">
+        <div className="flex items-center gap-4">
+          <ProtocolLogo scope={protocol.scope} name={protocol.name} size="sm" />
+          <div className="min-w-0">
+            <h3 className="text-lg font-semibold truncate leading-tight">{protocol.name}</h3>
+            <div className="mt-0.5 text-sm">
+              <span className="text-primary-600">@{protocol.scope}</span>
+              <span className="text-zinc-400"> • v{protocol.version}</span>
+            </div>
           </div>
         </div>
+        {protocol.description && (
+          <p className="text-sm text-zinc-400 line-clamp-3">
+            {protocol.description}
+          </p>
+        )}
       </div>
     </Link>
   );
@@ -47,9 +54,9 @@ export function Catalogue({ className, protocols }: CatalogueProps) {
   const endCursor = +(protocols.pageInfo.endCursor ?? 0) + 1;
   const totalNodes = protocols.metadata?.totalNodes ?? 0;
   return (
-    <section className={clsx('container px-[162px]', className)}>
-      <div className="flex justify-between items-center">
-        <h2 className="text-3xl font-semibold">Protocols</h2>
+    <section className={clsx('container lg:px-[162px]', className)}>
+      <div className="flex flex-wrap justify-between items-center gap-4">
+        <h2 className="text-2xl sm:text-3xl font-semibold">Protocols</h2>
         <Dropdown
           label="Sort by:"
           value={searchParams.get('sort') ?? DEFAULT_SORT}
@@ -61,7 +68,7 @@ export function Catalogue({ className, protocols }: CatalogueProps) {
           }}
         />
       </div>
-      <div className="grid grid-cols-3 gap-6 mt-8">
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 sm:gap-6 mt-8">
         {protocols.nodes.map(protocol => (
           <PackageCard key={`protocol-${protocol.id}`} protocol={protocol} />
         ))}

--- a/frontend/app/pages/protocol/details/index.tsx
+++ b/frontend/app/pages/protocol/details/index.tsx
@@ -71,7 +71,7 @@ export function ProtocolDetails({ protocol, rpcDocsUrl }: ProtocolDetailsProps) 
   return (
     <>
       <Header
-        centerNode={<SearchBar className="md:max-w-[426px] mx-auto max-h-11" dark />}
+        centerNode={<SearchBar className="hidden md:flex md:max-w-[426px] mx-auto max-h-11" dark />}
       />
       <main className="mt-8 flex flex-col flex-1">
         <div className="container relative after:content-[''] after:absolute after:w-[719px] after:h-[559.95px] after:bg-[radial-gradient(ellipse_359px_280px_at_center,#5A5BED_0%,rgba(37,45,71,0)_100%)] after:-right-[223px] after:-top-12.5 after:-z-1 after:opacity-15">
@@ -88,7 +88,7 @@ export function ProtocolDetails({ protocol, rpcDocsUrl }: ProtocolDetailsProps) 
             </div>
           </div>
 
-          <div className="flex mt-8 gap-2">
+          <div className="flex mt-8 gap-2 -mx-4 sm:-mx-8 lg:mx-0 px-4 sm:px-8 lg:px-0 overflow-x-auto custom-scrollbar">
             <TabName
               icon={<InfoCircleIcon width="20" height="20" />}
               name="Readme"

--- a/frontend/app/pages/protocol/details/tab/protocol.tsx
+++ b/frontend/app/pages/protocol/details/tab/protocol.tsx
@@ -20,17 +20,17 @@ function PartiesSection({ parties }: { parties: Party[]; }) {
         The participants involved in this protocol's transactions.
       </p>
       <div className="bg-zinc-950 border border-zinc-800 rounded-md overflow-hidden">
-        <div className="px-5 py-2.5 border-b border-zinc-800 flex text-xs font-medium text-zinc-500 uppercase tracking-wider">
+        <div className="hidden sm:flex px-5 py-2.5 border-b border-zinc-800 text-xs font-medium text-zinc-500 uppercase tracking-wider">
           <span className="flex-1 basis-1/3">Name</span>
           <span className="flex-1 basis-2/3">Description</span>
         </div>
         {parties.map(party => (
           <div
             key={party.name}
-            className="px-5 py-3 border-b last:border-b-0 border-zinc-800/50 flex items-baseline"
+            className="px-4 sm:px-5 py-3 border-b last:border-b-0 border-zinc-800/50 flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-0"
           >
-            <span className="flex-1 basis-1/3 text-zinc-50 font-medium text-sm">{party.name}</span>
-            <span className="flex-1 basis-2/3 text-zinc-500 text-sm">
+            <span className="sm:flex-1 sm:basis-1/3 text-zinc-50 font-medium text-sm break-words min-w-0">{party.name}</span>
+            <span className="sm:flex-1 sm:basis-2/3 text-zinc-500 text-sm break-words min-w-0">
               {party.description || '\u2014'}
             </span>
           </div>
@@ -50,7 +50,7 @@ function EnvironmentSection({ environment }: { environment: EnvironmentParam[]; 
         Configuration values required to execute this protocol's transactions.
       </p>
       <div className="bg-zinc-950 border border-zinc-800 rounded-md overflow-hidden">
-        <div className="px-5 py-2.5 border-b border-zinc-800 flex text-xs font-medium text-zinc-500 uppercase tracking-wider">
+        <div className="hidden sm:flex px-5 py-2.5 border-b border-zinc-800 text-xs font-medium text-zinc-500 uppercase tracking-wider">
           <span className="flex-1 basis-1/4">Name</span>
           <span className="flex-1 basis-2/4">Description</span>
           <span className="w-40 text-right">Type</span>
@@ -58,13 +58,13 @@ function EnvironmentSection({ environment }: { environment: EnvironmentParam[]; 
         {environment.map(env => (
           <div
             key={env.name}
-            className="px-5 py-3 border-b last:border-b-0 border-zinc-800/50 flex items-baseline"
+            className="px-4 sm:px-5 py-3 border-b last:border-b-0 border-zinc-800/50 flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-0"
           >
-            <span className="flex-1 basis-1/4 text-zinc-50 font-mono text-sm">{env.name}</span>
-            <span className="flex-1 basis-2/4 text-zinc-500 text-sm">
+            <span className="sm:flex-1 sm:basis-1/4 text-zinc-50 font-mono text-sm break-all min-w-0">{env.name}</span>
+            <span className="sm:flex-1 sm:basis-2/4 text-zinc-500 text-sm break-words min-w-0">
               {env.description || '\u2014'}
             </span>
-            <span className="w-40 text-right text-zinc-500 font-mono text-sm">{env.type}</span>
+            <span className="sm:w-40 sm:text-right text-zinc-500 font-mono text-sm break-all">{env.type}</span>
           </div>
         ))}
       </div>
@@ -105,7 +105,7 @@ function ProfilesSection({ profiles }: { profiles: Profile[]; }) {
                 )}
               </div>
               <div className="bg-zinc-950 border border-zinc-800 rounded-md overflow-hidden">
-                <div className="px-5 py-2.5 border-b border-zinc-800 flex text-xs font-medium text-zinc-500 uppercase tracking-wider">
+                <div className="hidden sm:flex px-5 py-2.5 border-b border-zinc-800 text-xs font-medium text-zinc-500 uppercase tracking-wider">
                   <span className="flex-1 basis-1/4">Key</span>
                   <span className="flex-1 basis-2/4">Value</span>
                   <span className="w-20 text-right">Type</span>
@@ -113,11 +113,11 @@ function ProfilesSection({ profiles }: { profiles: Profile[]; }) {
                 {rows.map(row => (
                   <div
                     key={row.key}
-                    className="px-5 py-3 border-b last:border-b-0 border-zinc-800/50 flex items-baseline"
+                    className="px-4 sm:px-5 py-3 border-b last:border-b-0 border-zinc-800/50 flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-0"
                   >
-                    <span className="flex-1 basis-1/4 text-zinc-400 font-mono text-sm">{row.key}</span>
-                    <span className="flex-1 basis-2/4 text-zinc-50 font-mono text-sm break-all">{row.value}</span>
-                    <span className={`w-20 text-right text-xs font-medium ${row.kind === 'party' ? 'text-indigo-400' : 'text-emerald-400'}`}>
+                    <span className="sm:flex-1 sm:basis-1/4 text-zinc-400 font-mono text-sm break-all min-w-0">{row.key}</span>
+                    <span className="sm:flex-1 sm:basis-2/4 text-zinc-50 font-mono text-sm break-all min-w-0">{row.value}</span>
+                    <span className={`sm:w-20 sm:text-right text-xs font-medium ${row.kind === 'party' ? 'text-indigo-400' : 'text-emerald-400'}`}>
                       {row.kind}
                     </span>
                   </div>
@@ -137,18 +137,18 @@ function TransactionDetail({ tx }: { tx: Tx; }) {
 
   return (
     <div className="bg-zinc-950 border border-zinc-800 rounded-md overflow-hidden">
-      <div className="px-8 py-5 border-b border-zinc-800">
-        <p className="text-zinc-50 text-lg font-medium">{tx.name}</p>
+      <div className="px-5 sm:px-8 py-5 border-b border-zinc-800">
+        <p className="text-zinc-50 text-lg font-medium break-words">{tx.name}</p>
         {tx.description && (
-          <p className="text-zinc-500 text-sm mt-1">{tx.description}</p>
+          <p className="text-zinc-500 text-sm mt-1 break-words">{tx.description}</p>
         )}
       </div>
 
-      <div className="px-8 py-5 space-y-6">
+      <div className="px-5 sm:px-8 py-5 space-y-6">
         {tx.svg && (
           <div>
             <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-2">Diagram</p>
-            <div dangerouslySetInnerHTML={{ __html: tx.svg }} />
+            <div className="overflow-x-auto custom-scrollbar [&_svg]:max-w-full [&_svg]:h-auto" dangerouslySetInnerHTML={{ __html: tx.svg }} />
           </div>
         )}
 
@@ -156,16 +156,16 @@ function TransactionDetail({ tx }: { tx: Tx; }) {
           <div>
             <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-2">Parameters</p>
             <div className="border border-zinc-800 rounded-md overflow-hidden">
-              <div className="px-4 py-2 border-b border-zinc-800 flex text-xs font-medium text-zinc-600 uppercase tracking-wider">
+              <div className="hidden sm:flex px-4 py-2 border-b border-zinc-800 text-xs font-medium text-zinc-600 uppercase tracking-wider">
                 <span className="flex-1 basis-1/3">Name</span>
                 <span className="flex-1 basis-1/3">Type</span>
                 <span className="flex-1 basis-1/3">Description</span>
               </div>
               {tx.parameters.map(param => (
-                <div key={param.name} className="px-4 py-2.5 border-b last:border-b-0 border-zinc-800/50 flex items-baseline">
-                  <span className="flex-1 basis-1/3 text-zinc-50 font-mono text-sm">{param.name}</span>
-                  <span className="flex-1 basis-1/3 text-zinc-500 font-mono text-sm">{param.type}</span>
-                  <span className="flex-1 basis-1/3 text-zinc-500 text-sm">{param.description || '\u2014'}</span>
+                <div key={param.name} className="px-4 py-2.5 border-b last:border-b-0 border-zinc-800/50 flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-0">
+                  <span className="sm:flex-1 sm:basis-1/3 text-zinc-50 font-mono text-sm break-all min-w-0">{param.name}</span>
+                  <span className="sm:flex-1 sm:basis-1/3 text-zinc-500 font-mono text-sm break-all min-w-0">{param.type}</span>
+                  <span className="sm:flex-1 sm:basis-1/3 text-zinc-500 text-sm break-words min-w-0">{param.description || '\u2014'}</span>
                 </div>
               ))}
             </div>
@@ -176,16 +176,16 @@ function TransactionDetail({ tx }: { tx: Tx; }) {
           <div>
             <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-2">Inputs</p>
             <div className="border border-zinc-800 rounded-md overflow-hidden">
-              <div className="px-4 py-2 border-b border-zinc-800 flex text-xs font-medium text-zinc-600 uppercase tracking-wider">
+              <div className="hidden sm:flex px-4 py-2 border-b border-zinc-800 text-xs font-medium text-zinc-600 uppercase tracking-wider">
                 <span className="flex-1 basis-1/3">Name</span>
                 <span className="flex-1 basis-1/3">Party</span>
                 <span className="w-28 text-right">Redeemer</span>
               </div>
               {inputs.map(input => (
-                <div key={input.name} className="px-4 py-2.5 border-b last:border-b-0 border-zinc-800/50 flex items-baseline">
-                  <span className="flex-1 basis-1/3 text-zinc-50 font-mono text-sm">{input.name}</span>
-                  <span className="flex-1 basis-1/3 text-indigo-400 text-sm">{input.party || '\u2014'}</span>
-                  <span className="w-28 text-right">
+                <div key={input.name} className="px-4 py-2.5 border-b last:border-b-0 border-zinc-800/50 flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-0">
+                  <span className="sm:flex-1 sm:basis-1/3 text-zinc-50 font-mono text-sm break-all min-w-0">{input.name}</span>
+                  <span className="sm:flex-1 sm:basis-1/3 text-indigo-400 text-sm break-all min-w-0">{input.party || '\u2014'}</span>
+                  <span className="sm:w-28 sm:text-right">
                     {input.hasRedeemer
                       ? <span className="text-amber-400 text-xs font-medium">script</span>
                       : <span className="text-zinc-600 text-xs">wallet</span>}
@@ -200,20 +200,20 @@ function TransactionDetail({ tx }: { tx: Tx; }) {
           <div>
             <p className="text-xs font-medium text-zinc-500 uppercase tracking-wider mb-2">Outputs</p>
             <div className="border border-zinc-800 rounded-md overflow-hidden">
-              <div className="px-4 py-2 border-b border-zinc-800 flex text-xs font-medium text-zinc-600 uppercase tracking-wider">
+              <div className="hidden sm:flex px-4 py-2 border-b border-zinc-800 text-xs font-medium text-zinc-600 uppercase tracking-wider">
                 <span className="flex-1 basis-1/3">Party</span>
                 <span className="flex-1 basis-1/3">Datum</span>
                 <span className="w-28 text-right">Optional</span>
               </div>
               {outputs.map((output, i) => (
-                <div key={i} className="px-4 py-2.5 border-b last:border-b-0 border-zinc-800/50 flex items-baseline">
-                  <span className="flex-1 basis-1/3 text-indigo-400 text-sm">{output.party || '\u2014'}</span>
-                  <span className="flex-1 basis-1/3">
+                <div key={i} className="px-4 py-2.5 border-b last:border-b-0 border-zinc-800/50 flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-0">
+                  <span className="sm:flex-1 sm:basis-1/3 text-indigo-400 text-sm break-all min-w-0">{output.party || '\u2014'}</span>
+                  <span className="sm:flex-1 sm:basis-1/3">
                     {output.hasDatum
                       ? <span className="text-emerald-400 text-xs font-medium">yes</span>
                       : <span className="text-zinc-600 text-xs">no</span>}
                   </span>
-                  <span className="w-28 text-right">
+                  <span className="sm:w-28 sm:text-right">
                     {output.optional
                       ? <span className="text-amber-400 text-xs font-medium">yes</span>
                       : <span className="text-zinc-600 text-xs">no</span>}

--- a/frontend/app/pages/protocol/details/tab/readme.tsx
+++ b/frontend/app/pages/protocol/details/tab/readme.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export function TabReadme({ protocol }: Props) {
-  const markdownClasses = 'w-full max-w-none bg-woodsmoke-950 py-8 pr-8 prose prose-sm prose-tx3' // Base
+  const markdownClasses = 'w-full max-w-none min-w-0 bg-woodsmoke-950 py-8 lg:pr-8 prose prose-sm prose-tx3' // Base
     + ' prose-headings:border-b prose-headings:border-zinc-800 prose-headings:pb-1.5' // Headings
     + ' prose-pre:whitespace-pre-wrap prose-pre:break-words'; // Preformatted
 
@@ -19,7 +19,7 @@ export function TabReadme({ protocol }: Props) {
 
   return (
     <div className="bg-zinc-950 flex flex-col flex-1">
-      <div className="flex container flex-1 bg-gradient-to-r from-woodsmoke-950 from-50% to-zinc-950 to-50%">
+      <div className="flex flex-col lg:flex-row container flex-1 bg-woodsmoke-950 lg:bg-gradient-to-r lg:from-woodsmoke-950 lg:from-50% lg:to-zinc-950 lg:to-50%">
         {protocol.readme
           ? (
             <div className={markdownClasses}>
@@ -38,7 +38,7 @@ export function TabReadme({ protocol }: Props) {
             </div>
           )
           : (
-            <div className="w-full bg-woodsmoke-950 py-8 pr-8">
+            <div className="w-full bg-woodsmoke-950 py-8 lg:pr-8">
               {isUnofficial && <UnofficialBanner />}
               <EmptyState
                 title="No README"
@@ -46,7 +46,10 @@ export function TabReadme({ protocol }: Props) {
               />
             </div>
           )}
-        <Info protocol={protocol} className="max-w-[400px] bg-zinc-950 border-l border-zinc-800 p-8" />
+        <Info
+          protocol={protocol}
+          className="w-full lg:max-w-[400px] bg-zinc-950 border-t lg:border-t-0 lg:border-l border-zinc-800 p-6 lg:p-8"
+        />
       </div>
     </div>
   );

--- a/frontend/app/pages/protocol/details/tab/sdks.tsx
+++ b/frontend/app/pages/protocol/details/tab/sdks.tsx
@@ -316,9 +316,11 @@ export function TabSDKs({ protocol }: Props) {
     el?.scrollIntoView({ behavior: 'smooth', block: 'start' });
   }, []);
 
+  const sdkOptions = sdks.map(s => ({ label: s.name, value: s.key }));
+
   return (
     <div className="container flex-1 flex py-8 items-start">
-      <aside className="w-56 shrink-0 sticky top-6 self-start max-h-[calc(100vh-3rem)] pr-10 overflow-y-auto custom-scrollbar">
+      <aside className="hidden lg:block w-56 shrink-0 sticky top-6 self-start max-h-[calc(100vh-3rem)] pr-10 overflow-y-auto custom-scrollbar">
         <SidebarLabel>SDKs</SidebarLabel>
         <div className="flex flex-col gap-1">
           {sdks.map(sdk => (
@@ -348,8 +350,20 @@ export function TabSDKs({ protocol }: Props) {
         )}
       </aside>
 
-      <section className="flex-1 min-w-0 flex flex-col gap-10 pl-10 border-l border-zinc-800">
-        <h2 className="text-2xl font-semibold text-zinc-50">{selected.title}</h2>
+      <section className="flex-1 min-w-0 flex flex-col gap-10 lg:pl-10 lg:border-l lg:border-zinc-800">
+        <div className="flex items-center justify-between gap-4 flex-wrap">
+          <h2 className="text-2xl font-semibold text-zinc-50">{selected.title}</h2>
+          <div className="lg:hidden">
+            <Dropdown
+              label="SDK"
+              showValue
+              modal={false}
+              value={selectedKey}
+              options={sdkOptions}
+              onOptionSelected={value => setSelectedKey(value as SDKKey)}
+            />
+          </div>
+        </div>
         <SetupSection steps={snippet.setupSteps} />
         <QuickStartSection
           snippet={snippet}

--- a/frontend/app/pages/protocol/details/tab/tryOut.tsx
+++ b/frontend/app/pages/protocol/details/tab/tryOut.tsx
@@ -158,18 +158,18 @@ const Transaction: React.FunctionComponent<TransactionProps> = props => {
 
   return (
     <div className="w-full border border-zinc-800 bg-zinc-950 rounded-md">
-      <div className="py-3 px-8 flex justify-between items-center border-b border-zinc-800">
-        <div>
-          <h3 className="text-lg text-zinc-400">
+      <div className="py-3 px-5 sm:px-8 flex flex-col sm:flex-row sm:justify-between sm:items-center gap-4 border-b border-zinc-800">
+        <div className="min-w-0">
+          <h3 className="text-lg text-zinc-400 break-words">
             <span className="font-semibold text-zinc-50">{props.tx.name}</span> parameters
           </h3>
           {!!props.tx.description && (
-            <p className="mt-3.5 text-zinc-600">
+            <p className="mt-3.5 text-zinc-600 break-words">
               {props.tx.description}
             </p>
           )}
         </div>
-        <div className="flex gap-5 items-center">
+        <div className="flex flex-wrap gap-3 sm:gap-5 items-center">
           {hasProfiles && (
             <Dropdown
               label="Profile"
@@ -182,22 +182,22 @@ const Transaction: React.FunctionComponent<TransactionProps> = props => {
           <LoadingButton asyncOnClick={handleExecute} />
         </div>
       </div>
-      <div className="px-8 py-5">
-        <p className="border-b border-zinc-900 text-zinc-700 pb-1 flex">
+      <div className="px-5 sm:px-8 py-5">
+        <p className="hidden sm:flex border-b border-zinc-900 text-zinc-700 pb-1">
           <span className="flex-1 basis-1/4">Name</span>
           <span className="flex-1 basis-3/4">Value</span>
         </p>
         {props.tx.parameters.map(param => (
-          <div key={param.name} className="border-b last:border-b-0 border-zinc-900 flex py-4 last:pb-0 gap-1">
-            <div className="flex-1 basis-1/4">
+          <div key={param.name} className="border-b last:border-b-0 border-zinc-900 flex flex-col sm:flex-row py-4 last:pb-0 gap-3 sm:gap-1">
+            <div className="sm:flex-1 sm:basis-1/4 min-w-0">
               <p className="text-zinc-50 text-base wrap-anywhere">
                 {param.name} <span className="text-rose-400">*</span>
               </p>
-              <p className="text-zinc-600 text-sm font-mono mt-2">
+              <p className="text-zinc-600 text-sm font-mono mt-2 break-all">
                 {param.type}
               </p>
             </div>
-            <div className="flex-1 basis-3/4 flex flex-col gap-3">
+            <div className="sm:flex-1 sm:basis-3/4 flex flex-col gap-3 min-w-0">
               <input
                 type={param.type === 'Int' ? 'number' : 'text'}
                 className="w-full rounded-lg py-2.5 px-4 bg-woodsmoke-950 border border-zinc-800 text-zinc-100 text-sm"
@@ -205,7 +205,7 @@ const Transaction: React.FunctionComponent<TransactionProps> = props => {
                 onChange={e => updateParameter(param.name, param.type, e.target.value)}
               />
               {!!param.description && (
-                <p className="text-xs text-zinc-400">
+                <p className="text-xs text-zinc-400 break-words">
                   {param.description}
                 </p>
               )}
@@ -216,7 +216,7 @@ const Transaction: React.FunctionComponent<TransactionProps> = props => {
       </div>
 
       {response && (
-        <div className="px-8 py-6 max-h-55 flex">
+        <div className="px-5 sm:px-8 py-6 max-h-55 flex">
           <Alert type={response.type} title="Response" textToCopy={response.message}>
             {response.message}
           </Alert>


### PR DESCRIPTION
## Summary
- Make the registry frontend usable on mobile across the homepage and the protocol detail tabs (readme, protocol, try-out, sdks).
- Surface each protocol's short description on the catalogue card.

### Layout changes
- `container` utility now uses responsive horizontal padding (`px-4 sm:px-8 lg:px-20`) instead of a fixed `px-20`.
- Hero title scales `text-2xl → text-3xl → text-4xl`; subtitle tightened (`leading-tight`, `mt-0.5`, smaller scope/version).
- Catalogue: grid is `1 / 2 / 3` columns; cards stretch to equal height (`h-full` + `flex-col`) and now include the protocol description clamped to 3 lines (`line-clamp-3`). `description` was added to the list GraphQL query.
- Protocol detail header: tab row is a horizontally scrollable strip (`overflow-x-auto`) with `shrink-0 whitespace-nowrap` tab buttons; the centered SearchBar is hidden below `md`.
- Readme tab: the Info sidebar stacks below the markdown on `<lg`; the split-background gradient and right padding are now `lg:` only; `min-w-0` on the prose container prevents long code blocks from blowing the flex row.
- Protocol tab tables (parties, environment, profile rows, tx parameters/inputs/outputs): rows go `flex-col sm:flex-row`, headers are `hidden sm:flex`, cells gain `min-w-0` and `break-words`/`break-all` so long names, types and addresses wrap instead of pushing the layout. The tx diagram SVG container is bounded with `overflow-x-auto` and `[&_svg]:max-w-full h-auto`.
- Try-out tab: card header (title + Profile dropdown + Execute) wraps below `sm`; parameter rows stack vertically with `min-w-0` on both columns.
- SDKs tab: the left rail is `hidden lg:block`; an SDK `Dropdown` appears in the section header on `<lg` so users can still switch language.

## Test plan
- [ ] Open `/protocols` at 375px width and confirm the catalogue grid is single-column, cards are readable, and descriptions truncate at ~3 lines.
- [ ] At ≥1024px, verify the catalogue still renders as a 3-column grid with the previous side padding.
- [ ] Open a protocol detail page on mobile and confirm:
  - [ ] Tab strip scrolls horizontally and active tab is reachable without clipping
  - [ ] Readme tab stacks the Info panel below the README
  - [ ] Protocol tab tables stack each row vertically; long addresses/types wrap
  - [ ] Try-out tab header wraps and parameter inputs are full-width
  - [ ] SDKs tab shows the SDK dropdown in the body and hides the left rail
- [ ] On desktop, confirm none of the above tabs changed visually (sidebars still present, tables still use proportional columns).