### PR TITLE
feat(frontend): simplify quick-start to use trix codegen --plugin

### DIFF
--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -164,30 +164,16 @@ export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] 
     {
       kind: 'shell',
       lang: 'bash',
-      title: 'Initialize a trix project',
-      body: 'trix init',
-      note: 'Skip this step if you already have a trix project.',
-    },
-    {
-      kind: 'shell',
-      lang: 'bash',
       title: 'Install the protocol',
       body: `trix use ${ref}`,
-      note: 'Downloads the compiled .tii into your trix project and registers it as a dependency.',
-    },
-    {
-      kind: 'toml',
-      lang: 'toml',
-      title: 'Configure codegen',
-      body: bindingsTomlBlock(lang),
-      note: 'Add this entry to trix.toml so trix knows which language to generate.',
+      note: 'Auto-bootstraps a trix.toml in the current directory if none exists, then downloads the compiled .tii and pins the dependency.',
     },
     {
       kind: 'shell',
       lang: 'bash',
       title: 'Generate the client',
-      body: 'trix codegen',
-      note: `Writes the typed client to ${OUTPUT_DIR[lang]}.`,
+      body: `trix codegen --plugin ${CODEGEN_PLUGIN[lang]}`,
+      note: `Adds the [[codegen]] entry to trix.toml on first run and writes the typed client (defaults to .tx3/codegen/${CODEGEN_PLUGIN[lang]}/; override with output_dir in trix.toml).`,
     },
   ];
 }


### PR DESCRIPTION
## Summary

The trix CLI gained two consumer-flow simplifications:

1. `trix use <ref>` auto-bootstraps a consumer-shape `trix.toml` when none is found
2. `trix codegen --plugin <name>` seeds the `[[codegen]]` entry on first run

The protocol-page quick-start snippet was teaching the old, longer flow (separate `trix init` step, manual TOML block for codegen config). After this PR the visible steps are:

1. Install the Tx3 toolchain
2. `trix use <ref>`
3. `trix codegen --plugin <plugin>`
4. (per-SDK) install the runtime via `postCodegenInstall`

`bindingsTomlBlock` / `outputDir` / `bindingPlugin` stay exported as a manual escape hatch for users who want to hand-edit `trix.toml`.

Pairs with the trix PR and the docs PR.

## Test plan

- [ ] Render a protocol page locally and verify the Quick Start tab shows the three-step shell flow for each language
- [ ] Confirm the language-specific `postCodegenInstall` step still renders where applicable (TS/Go/Python)