### PR TITLE
fix(frontend): use ':' as version separator in trix use reference

### DIFF
--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -152,7 +152,7 @@ export function outputDir(lang: SDKKey): string {
 
 // Shared install-flow steps. Each renderer prepends its own SDK install step.
 export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] {
-  const ref = `${protocol.scope}/${protocol.name}@${protocol.version}`;
+  const ref = `${protocol.scope}/${protocol.name}:${protocol.version}`;
   return [
     {
       kind: 'shell',


### PR DESCRIPTION
## Summary

`trix use` accepts `<scope>/<name>:<version>` (see `ProtocolRef::parse_registry` in the trix repo); the `@` form is rejected. The protocol-page quick-start snippet was rendering the reference with `@`, so copy-paste from the page failed:

\`\`\`
error: invalid value 'open-tx3/vyfi@0.1.0' for '<REFERENCE>': invalid identifier 'vyfi@0.1.0'
\`\`\`

One-character fix in `commonSetupSteps`.

## Test plan

- [ ] Load a protocol page, copy the \"Install the protocol\" command, and confirm it runs successfully against a real protocol (e.g. \`trix use open-tx3/vyfi:0.1.0\`)