### PR TITLE
feat(frontend): readme collapse, tx nav, hero copy, snippet placeholders

### DIFF
--- a/frontend/app/components/Hero.tsx
+++ b/frontend/app/components/Hero.tsx
@@ -9,7 +9,7 @@ interface Props {
 export function Hero({ className, onSearch }: Props) {
   return (
     <section className={clsx('px-4 sm:px-8', className)}>
-      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center tracking-wide">Registry for UTxO Protocols</h1>
+      <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-center tracking-wide">UTxO Protocol Registry</h1>
       <SearchBar className="mt-8 mx-auto max-w-[836px]" onSearch={onSearch} />
     </section>
   );

--- a/frontend/app/pages/landing/Hero.tsx
+++ b/frontend/app/pages/landing/Hero.tsx
@@ -19,8 +19,8 @@ export function Hero() {
           </h1>
 
           <p className="max-w-[760px] text-zinc-400 text-lg leading-7">
-            Protocol authors publish a spec. Application developers generate typed clients from it.
-            The interface is data, not lore.
+            Protocol authors publish a spec. Application developers generate
+            typed clients from it.
           </p>
         </div>
 
@@ -38,8 +38,9 @@ export function Hero() {
             </h2>
 
             <p className="text-[15px] leading-6 text-zinc-300">
-              Declare what your protocol exposes in a .tx3 spec — parties, types, transactions. Ship it as a
-              TII artifact that any consumer can read.
+              Declare what your protocol exposes in a .tx3 spec — parties,
+              types, transactions. Ship it as a TII artifact that any consumer
+              can read.
             </p>
 
             <div className="mt-auto flex flex-wrap items-center gap-4 pt-2">
@@ -50,7 +51,11 @@ export function Hero() {
                 className="group inline-flex items-center gap-2.5 bg-primary-600 hover:bg-primary-700 text-zinc-50 rounded-lg px-5 py-3 text-sm font-semibold transition-colors shadow-[0_10px_30px_-12px_rgba(255,0,127,0.55)]"
               >
                 Author a protocol
-                <ArrowRightIcon width={16} height={16} className="transition-transform group-hover:translate-x-0.5" />
+                <ArrowRightIcon
+                  width={16}
+                  height={16}
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
               </a>
               <a
                 href={docsUrl}
@@ -59,7 +64,11 @@ export function Hero() {
                 className="group inline-flex items-center gap-2 text-sm text-zinc-300 hover:text-zinc-50 transition-colors"
               >
                 Read the spec
-                <ArrowRightIcon width={16} height={16} className="transition-transform group-hover:translate-x-0.5" />
+                <ArrowRightIcon
+                  width={16}
+                  height={16}
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
               </a>
             </div>
           </article>
@@ -77,8 +86,8 @@ export function Hero() {
             </h2>
 
             <p className="text-[15px] leading-6 text-zinc-300">
-              Generate a typed client from a published .tii and invoke protocol transactions from
-              TypeScript, Rust, Go or Python.
+              Generate a typed client from a published .tii and invoke protocol
+              transactions from TypeScript, Rust, Go or Python.
             </p>
 
             <div className="mt-auto flex flex-wrap items-center gap-4 pt-2">
@@ -87,21 +96,30 @@ export function Hero() {
                 className="group inline-flex items-center gap-2.5 bg-blue-500 hover:bg-blue-600 text-zinc-50 rounded-lg px-5 py-3 text-sm font-semibold transition-colors shadow-[0_10px_30px_-12px_rgba(43,127,255,0.55)]"
               >
                 Consume a protocol
-                <ArrowRightIcon width={16} height={16} className="transition-transform group-hover:translate-x-0.5" />
+                <ArrowRightIcon
+                  width={16}
+                  height={16}
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
               </Link>
               <Link
                 to="/protocols"
                 className="group inline-flex items-center gap-2 text-sm text-zinc-300 hover:text-zinc-50 transition-colors"
               >
                 Browse the registry
-                <ArrowRightIcon width={16} height={16} className="transition-transform group-hover:translate-x-0.5" />
+                <ArrowRightIcon
+                  width={16}
+                  height={16}
+                  className="transition-transform group-hover:translate-x-0.5"
+                />
               </Link>
             </div>
           </article>
         </div>
 
         <p className="text-xs text-zinc-500 tracking-wide text-center">
-          Open source&nbsp;&nbsp;·&nbsp;&nbsp;Apache 2.0&nbsp;&nbsp;·&nbsp;&nbsp;
+          Open source&nbsp;&nbsp;·&nbsp;&nbsp;Apache
+          2.0&nbsp;&nbsp;·&nbsp;&nbsp;
           <a
             href={docsUrl}
             target="_blank"

--- a/frontend/app/pages/protocol/details/index.tsx
+++ b/frontend/app/pages/protocol/details/index.tsx
@@ -29,7 +29,7 @@ import { TabActivity } from './tab/activity';
 export const UNOFFICIAL_SCOPE = 'open-tx3';
 export const UNOFFICIAL_DISCLAIMER
   = 'Preliminary, reverse-engineered version published by the tx3 team for testing and exploration. '
-  + 'It is not endorsed by the original protocol authors. Do not use in mainnet.';
+    + 'It is not endorsed by the original protocol authors. Do not use in mainnet.';
 
 function UnofficialBadge() {
   return (

--- a/frontend/app/pages/protocol/details/tab/protocol.tsx
+++ b/frontend/app/pages/protocol/details/tab/protocol.tsx
@@ -1,6 +1,20 @@
+import clsx from 'clsx';
+import { useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+
 interface Props {
   protocol: Protocol;
 }
+
+// Stable anchor id for a transaction so other tabs can deep-link into it.
+export function txAnchor(name: string): string {
+  return `tx-${name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '')}`;
+}
+
+const SECTION_PARTIES = 'parties';
+const SECTION_ENVIRONMENT = 'environment';
+const SECTION_TRANSACTIONS = 'transactions';
+const SECTION_PROFILES = 'profiles';
 
 function SectionTitle({ children }: { children: React.ReactNode; }) {
   return (
@@ -14,7 +28,7 @@ function PartiesSection({ parties }: { parties: Party[]; }) {
   if (parties.length === 0) return null;
 
   return (
-    <section>
+    <section id={SECTION_PARTIES} className="scroll-mt-24">
       <SectionTitle>Parties</SectionTitle>
       <p className="text-zinc-500 text-sm mb-4">
         The participants involved in this protocol's transactions.
@@ -44,7 +58,7 @@ function EnvironmentSection({ environment }: { environment: EnvironmentParam[]; 
   if (environment.length === 0) return null;
 
   return (
-    <section>
+    <section id={SECTION_ENVIRONMENT} className="scroll-mt-24">
       <SectionTitle>Environment</SectionTitle>
       <p className="text-zinc-500 text-sm mb-4">
         Configuration values required to execute this protocol's transactions.
@@ -76,7 +90,7 @@ function ProfilesSection({ profiles }: { profiles: Profile[]; }) {
   if (profiles.length === 0) return null;
 
   return (
-    <section>
+    <section id={SECTION_PROFILES} className="scroll-mt-24">
       <SectionTitle>Profiles</SectionTitle>
       <p className="text-zinc-500 text-sm mb-4">
         Pre-configured sets of environment and party values for different deployment targets.
@@ -136,7 +150,7 @@ function TransactionDetail({ tx }: { tx: Tx; }) {
   const outputs = (tx as any).outputs as { party: string | null; hasDatum: boolean; optional: boolean; }[] | undefined;
 
   return (
-    <div className="bg-zinc-950 border border-zinc-800 rounded-md overflow-hidden">
+    <div id={txAnchor(tx.name)} className="bg-zinc-950 border border-zinc-800 rounded-md overflow-hidden scroll-mt-24">
       <div className="px-5 sm:px-8 py-5 border-b border-zinc-800">
         <p className="text-zinc-50 text-lg font-medium break-words">{tx.name}</p>
         {tx.description && (
@@ -232,7 +246,7 @@ function TransactionsSection({ transactions }: { transactions: Tx[]; }) {
   if (transactions.length === 0) return null;
 
   return (
-    <section>
+    <section id={SECTION_TRANSACTIONS} className="scroll-mt-24">
       <SectionTitle>Transactions</SectionTitle>
       <p className="text-zinc-500 text-sm mb-4">
         The transactions defined in this protocol, with their parameters, inputs, and outputs.
@@ -246,20 +260,132 @@ function TransactionsSection({ transactions }: { transactions: Tx[]; }) {
   );
 }
 
-export function TabProtocol({ protocol }: Props) {
+function TxTocButton({ name, active, onClick }: { name: string; active: boolean; onClick: () => void; }) {
   return (
-    <div className="container flex-1 py-8 space-y-10">
-      {protocol.description && (
-        <section>
-          <SectionTitle>About this Protocol</SectionTitle>
-          <p className="text-zinc-300 leading-relaxed">{protocol.description}</p>
-        </section>
+    <button
+      type="button"
+      onClick={onClick}
+      data-active={active}
+      className={clsx(
+        'text-left text-xs font-mono px-3 py-1.5 rounded transition-colors cursor-pointer truncate',
+        active
+          ? 'text-blue-400 bg-zinc-900'
+          : 'text-zinc-500 hover:text-zinc-200 hover:bg-zinc-900/40',
+      )}
+    >
+      {name}
+    </button>
+  );
+}
+
+function SectionTocButton({ label, active, onClick }: { label: string; active: boolean; onClick: () => void; }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-active={active}
+      className={clsx(
+        'text-left text-sm px-3 py-2 rounded transition-colors cursor-pointer truncate',
+        active
+          ? 'bg-zinc-900 text-zinc-50 border-l-2 border-l-blue-400 rounded-l-none'
+          : 'text-zinc-400 hover:bg-zinc-900/60 hover:text-zinc-200',
+      )}
+    >
+      {label}
+    </button>
+  );
+}
+
+function SidebarLabel({ children, className }: { children: React.ReactNode; className?: string; }) {
+  return (
+    <p className={clsx('text-xs font-medium text-zinc-500 uppercase tracking-wider px-3 mb-2', className)}>
+      {children}
+    </p>
+  );
+}
+
+export function TabProtocol({ protocol }: Props) {
+  const { hash, pathname, search } = useLocation();
+  const navigate = useNavigate();
+  const transactions = protocol.transactions ?? [];
+
+  // React Router doesn't scroll to hash fragments by default; do it manually
+  // when this tab mounts or the hash changes (e.g. arriving from a card link).
+  useEffect(() => {
+    if (!hash) return;
+    const el = document.getElementById(hash.slice(1));
+    if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }, [hash]);
+
+  const parties = protocol.parties ?? [];
+  const environment = protocol.environment ?? [];
+  const profiles = protocol.profiles ?? [];
+
+  const focusAnchor = (anchor: string) => {
+    if (hash === `#${anchor}`) {
+      document.getElementById(anchor)?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    } else {
+      navigate(`${pathname}${search}#${anchor}`);
+    }
+  };
+
+  const sections: { id: string; label: string; visible: boolean }[] = [
+    { id: SECTION_PARTIES, label: 'Parties', visible: parties.length > 0 },
+    { id: SECTION_ENVIRONMENT, label: 'Environment', visible: environment.length > 0 },
+    { id: SECTION_TRANSACTIONS, label: 'Transactions', visible: transactions.length > 0 },
+    { id: SECTION_PROFILES, label: 'Profiles', visible: profiles.length > 0 },
+  ].filter(s => s.visible);
+
+  const hasSidebar = sections.length > 0;
+
+  return (
+    <div className="container flex-1 flex py-8 items-start">
+      {hasSidebar && (
+        <aside className="hidden lg:block w-56 shrink-0 sticky top-6 self-start max-h-[calc(100vh-3rem)] pr-10 overflow-y-auto custom-scrollbar">
+          <SidebarLabel>Sections</SidebarLabel>
+          <div className="flex flex-col gap-1">
+            {sections.map(s => (
+              <div key={s.id}>
+                <SectionTocButton
+                  label={s.label}
+                  active={hash === `#${s.id}`}
+                  onClick={() => focusAnchor(s.id)}
+                />
+                {s.id === SECTION_TRANSACTIONS && transactions.length > 0 && (
+                  <div className="mt-1 ml-3 pl-3 border-l border-zinc-800 flex flex-col gap-0.5">
+                    {transactions.map(tx => (
+                      <TxTocButton
+                        key={tx.name}
+                        name={tx.name}
+                        active={hash === `#${txAnchor(tx.name)}`}
+                        onClick={() => focusAnchor(txAnchor(tx.name))}
+                      />
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </aside>
       )}
 
-      <PartiesSection parties={protocol.parties ?? []} />
-      <EnvironmentSection environment={protocol.environment ?? []} />
-      <TransactionsSection transactions={protocol.transactions ?? []} />
-      <ProfilesSection profiles={protocol.profiles ?? []} />
+      <div className={clsx(
+        'flex-1 min-w-0 space-y-10',
+        hasSidebar && 'lg:pl-10 lg:border-l lg:border-zinc-800',
+      )}
+      >
+        {protocol.description && (
+          <section>
+            <SectionTitle>About this Protocol</SectionTitle>
+            <p className="text-zinc-300 leading-relaxed">{protocol.description}</p>
+          </section>
+        )}
+
+        <PartiesSection parties={parties} />
+        <EnvironmentSection environment={environment} />
+        <TransactionsSection transactions={transactions} />
+        <ProfilesSection profiles={profiles} />
+      </div>
     </div>
   );
 }

--- a/frontend/app/pages/protocol/details/tab/protocol.tsx
+++ b/frontend/app/pages/protocol/details/tab/protocol.tsx
@@ -329,7 +329,7 @@ export function TabProtocol({ protocol }: Props) {
     }
   };
 
-  const sections: { id: string; label: string; visible: boolean }[] = [
+  const sections: { id: string; label: string; visible: boolean; }[] = [
     { id: SECTION_PARTIES, label: 'Parties', visible: parties.length > 0 },
     { id: SECTION_ENVIRONMENT, label: 'Environment', visible: environment.length > 0 },
     { id: SECTION_TRANSACTIONS, label: 'Transactions', visible: transactions.length > 0 },

--- a/frontend/app/pages/protocol/details/tab/readme.tsx
+++ b/frontend/app/pages/protocol/details/tab/readme.tsx
@@ -1,10 +1,15 @@
+import clsx from 'clsx';
+import { useEffect, useRef, useState, type PropsWithChildren } from 'react';
 import Markdown from 'react-markdown';
+import { Link } from 'react-router';
 import remarkGfm from 'remark-gfm';
 
 // Info
 import { EmptyState } from '~/components/EmptyState';
+import { ChevronDownIcon } from '~/components/icons/chevron-down';
 import { Info } from '../info';
 import { UNOFFICIAL_DISCLAIMER, UNOFFICIAL_SCOPE } from '../index';
+import { txAnchor } from './protocol';
 
 interface Props {
   protocol: Protocol;
@@ -20,38 +25,116 @@ export function TabReadme({ protocol }: Props) {
   return (
     <div className="bg-zinc-950 flex flex-col flex-1">
       <div className="flex flex-col lg:flex-row container flex-1 bg-woodsmoke-950 lg:bg-gradient-to-r lg:from-woodsmoke-950 lg:from-50% lg:to-zinc-950 lg:to-50%">
-        {protocol.readme
-          ? (
-            <div className={markdownClasses}>
-              {isUnofficial && <UnofficialBanner />}
-              <Markdown
-                remarkPlugins={[remarkGfm]}
-                components={{
-                  h1: 'h2',
-                  h2: 'h3',
-                  h3: 'h4',
-                  h4: 'h5',
-                }}
-              >
-                {protocol.readme}
-              </Markdown>
-            </div>
-          )
-          : (
-            <div className="w-full bg-woodsmoke-950 py-8 lg:pr-8">
-              {isUnofficial && <UnofficialBanner />}
+        <div className={markdownClasses}>
+          {isUnofficial && <UnofficialBanner />}
+          {protocol.readme
+            ? (
+              <CollapsibleReadme>
+                <Markdown
+                  remarkPlugins={[remarkGfm]}
+                  components={{
+                    h1: 'h2',
+                    h2: 'h3',
+                    h3: 'h4',
+                    h4: 'h5',
+                  }}
+                >
+                  {protocol.readme}
+                </Markdown>
+              </CollapsibleReadme>
+            )
+            : (
               <EmptyState
                 title="No README"
                 description="This Protocol doesn't have a README at the moment."
               />
-            </div>
-          )}
+            )}
+          {protocol.transactions.length > 0 && <TransactionsList transactions={protocol.transactions} />}
+        </div>
         <Info
           protocol={protocol}
           className="w-full lg:max-w-[400px] bg-zinc-950 border-t lg:border-t-0 lg:border-l border-zinc-800 p-6 lg:p-8"
         />
       </div>
     </div>
+  );
+}
+
+// Height tuned to comfortably show a heading and a couple of paragraphs.
+const COLLAPSED_HEIGHT_PX = 240;
+
+function CollapsibleReadme({ children }: PropsWithChildren) {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isOverflowing, setIsOverflowing] = useState(false);
+
+  useEffect(() => {
+    const el = contentRef.current;
+    if (!el) return;
+    const measure = () => setIsOverflowing(el.scrollHeight > COLLAPSED_HEIGHT_PX + 16);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  const clamp = isOverflowing && !isExpanded;
+
+  return (
+    <>
+      <div
+        ref={contentRef}
+        className="relative overflow-hidden"
+        style={{ maxHeight: clamp ? `${COLLAPSED_HEIGHT_PX}px` : 'none' }}
+      >
+        {children}
+        {clamp && (
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-32 bg-gradient-to-b from-transparent to-woodsmoke-950"
+          />
+        )}
+      </div>
+      {isOverflowing && (
+        <div className="not-prose mt-6 flex justify-center">
+          <button
+            type="button"
+            onClick={() => setIsExpanded(v => !v)}
+            aria-expanded={isExpanded}
+            className="inline-flex items-center gap-2 rounded-full border border-zinc-700 bg-zinc-900 px-5 py-2 text-sm font-medium text-zinc-200 hover:bg-zinc-800 hover:text-white hover:border-zinc-600 transition-colors cursor-pointer"
+          >
+            {isExpanded ? 'Show less' : 'Show more'}
+            <ChevronDownIcon
+              width="16"
+              height="16"
+              className={clsx('transition-transform duration-200', isExpanded && 'rotate-180')}
+            />
+          </button>
+        </div>
+      )}
+    </>
+  );
+}
+
+function TransactionsList({ transactions }: { transactions: Tx[] }) {
+  return (
+    <section className="not-prose mt-12">
+      <h2 className="text-lg font-semibold text-white mb-4">Transactions</h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {transactions.map(tx => (
+          <Link
+            key={tx.name}
+            to={`?activeTab=protocol#${txAnchor(tx.name)}`}
+            className="block rounded-lg border border-zinc-800 bg-zinc-900/40 p-4 hover:border-zinc-700 hover:bg-zinc-900/70 transition-colors"
+          >
+            <h3 className="font-mono text-sm font-semibold text-white">{tx.name}</h3>
+            {tx.description && (
+              <p className="mt-1.5 text-sm text-zinc-400 leading-relaxed">{tx.description}</p>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
   );
 }
 

--- a/frontend/app/pages/protocol/details/tab/readme.tsx
+++ b/frontend/app/pages/protocol/details/tab/readme.tsx
@@ -116,7 +116,7 @@ function CollapsibleReadme({ children }: PropsWithChildren) {
   );
 }
 
-function TransactionsList({ transactions }: { transactions: Tx[] }) {
+function TransactionsList({ transactions }: { transactions: Tx[]; }) {
   return (
     <section className="not-prose mt-12">
       <h2 className="text-lg font-semibold text-white mb-4">Transactions</h2>

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
@@ -9,14 +9,6 @@ import {
   userProvidedParams,
 } from './shared';
 
-function formatValue(value: unknown, type: string): string {
-  if (typeof value === 'boolean') return String(value);
-  if (typeof value === 'number') return String(value);
-  if (typeof value === 'bigint') return String(value);
-  if (type.toLowerCase() === 'int' && typeof value === 'string' && /^-?\d+$/.test(value)) return value;
-  return JSON.stringify(String(value));
-}
-
 function clientOptionsBlock(trp: TrpConfig): string[] {
   const endpoint = `    Endpoint: ${JSON.stringify(trp.endpoint)},`;
   if (!trp.headers) {
@@ -101,7 +93,7 @@ function txBlock(tx: Tx, protocol: Protocol): string {
     ].join('\n');
   }
   const argLines = params.map(param =>
-    `    ${toPascalCase(param.name)}: ${formatValue(placeholderFor(param.type), param.type)},`,
+    `    ${toPascalCase(param.name)}: ${JSON.stringify(placeholderFor(param.type))},`,
   );
   return [
     `resolved, err := client.${method}(${paramsType}{`,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
@@ -10,14 +10,6 @@ import {
   userProvidedParams,
 } from './shared';
 
-function formatValue(value: unknown, type: string): string {
-  if (typeof value === 'boolean') return value ? 'True' : 'False';
-  if (typeof value === 'number') return String(value);
-  if (typeof value === 'bigint') return String(value);
-  if (type.toLowerCase() === 'int' && typeof value === 'string' && /^-?\d+$/.test(value)) return value;
-  return JSON.stringify(String(value));
-}
-
 function pythonModule(protocol: Protocol): string {
   return `gen.python.${toSnakeCase(protocol.name)}`;
 }
@@ -77,7 +69,7 @@ function txBlock(tx: Tx, protocol: Protocol): string {
     ].join('\n');
   }
   const argLines = params.map(param =>
-    `    ${toSnakeCase(param.name)}=${formatValue(placeholderFor(param.type), param.type)},`,
+    `    ${toSnakeCase(param.name)}=${JSON.stringify(placeholderFor(param.type))},`,
   );
   return [
     paramsImport,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
@@ -47,7 +47,7 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
     'from tx3_sdk.signer import Ed25519Signer',
     'from tx3_sdk.trp.client import ClientOptions',
     '',
-    `signer = Ed25519Signer.from_hex("addr_test1...", "deadbeef...")`,
+    'signer = Ed25519Signer.from_hex("addr_test1...", "deadbeef...")',
     '',
     `client = Client(${clientOptionsLiteral(trp)}${profileArg})`,
     ...partyLines,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
@@ -9,14 +9,6 @@ import {
   userProvidedParams,
 } from './shared';
 
-function formatValue(value: unknown, type: string): string {
-  if (typeof value === 'boolean') return String(value);
-  if (typeof value === 'number') return String(value);
-  if (typeof value === 'bigint') return String(value);
-  if (type.toLowerCase() === 'int' && typeof value === 'string' && /^-?\d+$/.test(value)) return value;
-  return `${JSON.stringify(String(value))}.to_string()`;
-}
-
 function cratePath(protocol: Protocol): string {
   return toSnakeCase(protocol.name);
 }
@@ -91,7 +83,7 @@ function txBlock(tx: Tx, protocol: Protocol): string {
     return `let ${varName} = client.${method}(${paramsType} {}).resolve().await?;`;
   }
   const argLines = params.map(param =>
-    `    ${toSnakeCase(param.name)}: ${formatValue(placeholderFor(param.type), param.type)},`,
+    `    ${toSnakeCase(param.name)}: ${JSON.stringify(placeholderFor(param.type))}.to_string(),`,
   );
   return [
     `let ${varName} = client.${method}(${paramsType} {`,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -108,14 +108,12 @@ export function userProvidedParams(tx: Tx, protocol: Protocol, supplied: Set<str
     .sort(byName);
 }
 
-export function placeholderFor(type: string): unknown {
-  const t = type.toLowerCase();
-  if (t === 'int' || t === 'u64' || t === 'i64') return 0;
-  if (t === 'bool') return false;
-  if (t.includes('address')) return 'addr_test1...';
-  if (t.includes('bytes') || t.includes('hash')) return '0011223344';
-  if (t.includes('utxo')) return 'tx_hash#0';
-  return '...';
+// A typed placeholder rendered as a string literal in every target language.
+// Using a string literal regardless of the field's declared type keeps the
+// snippet syntactically valid (so syntax highlighting stays consistent) while
+// making it obvious to the reader that the value must be replaced.
+export function placeholderFor(type: string): string {
+  return `<input ${type}>`;
 }
 
 // Codegen plugin name per language target (matches `[[codegen]]` plugin keys

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
@@ -10,15 +10,6 @@ import {
   userProvidedParams,
 } from './shared';
 
-function formatValue(value: unknown, type: string): string {
-  if (typeof value === 'boolean') return String(value);
-  if (typeof value === 'number' && Number.isInteger(value)) return `${value}n`;
-  if (typeof value === 'number') return String(value);
-  if (typeof value === 'bigint') return `${value}n`;
-  if (type.toLowerCase() === 'int' && typeof value === 'string' && /^-?\d+$/.test(value)) return `${value}n`;
-  return JSON.stringify(String(value));
-}
-
 function clientOptionsLiteral(trp: TrpConfig): string {
   if (!trp.headers) {
     return `{ endpoint: ${JSON.stringify(trp.endpoint)} }`;
@@ -74,7 +65,7 @@ function txBlock(tx: Tx, protocol: Protocol): string {
     return `const ${varName} = await client.${method}({}).resolve();`;
   }
   const argLines = params.map(param =>
-    `  ${toCamelCase(param.name)}: ${formatValue(placeholderFor(param.type), param.type)},`,
+    `  ${toCamelCase(param.name)}: ${JSON.stringify(placeholderFor(param.type))},`,
   );
   return [
     `const ${varName} = await client.${method}({`,


### PR DESCRIPTION
## Summary
- **Hero**: rename "Registry for UTxO Protocols" → "UTxO Protocol Registry".
- **Readme tab**: clamp long READMEs to ~240px with a transparent→bg opacity gradient and a centered pill "Show more / Show less" toggle (only shows when content overflows). Below the readme, render a grid of callout cards listing each protocol transaction; each card links to the Protocol tab and scrolls to the matching tx anchor.
- **Protocol tab**: add a sticky left sidebar (mirrors the SDKs tab styling) listing the protocol's *Sections* — Parties / Environment / Transactions / Profiles — with the individual transactions nested under the Transactions entry. Section/tx anchors smooth-scroll on hash change.
- **SDKs quick-start**: render tx parameter placeholders as a uniform `"<input {type}>"` string literal across TS / Rust / Python / Go so the syntax highlighter stays happy and the placeholder text is self-describing instead of randomly-shaped sentinel values.

## Test plan
- [ ] Visit a protocol with a long README — confirm it's clamped, fade is visible, "Show more" expands to full height.
- [ ] Visit a protocol with a short README — confirm no toggle and no fade.
- [ ] Click a tx callout card under the README — confirm it switches to the Protocol tab and scrolls to that tx.
- [ ] On the Protocol tab, click sidebar Section entries — confirm each scrolls to the matching section header.
- [ ] On the Protocol tab, click a tx under the nested Transactions list — confirm scroll-to-tx and active highlight.
- [ ] On the SDKs tab, open every language tab and confirm placeholder args render as `"<input Int>"` etc. with no syntax-highlight errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)