### PR TITLE
fix: resolve protocols case-insensitively against OCI scope

### DIFF
--- a/backend/src/schema/protocol/query.rs
+++ b/backend/src/schema/protocol/query.rs
@@ -98,7 +98,12 @@ impl ProtocolQuery {
     }
 
     async fn protocol(&self, scope: String, name: String) -> Result<Option<Protocol>, Error> {
-        let repo = format!("{}/{}", scope, name);
+        // OCI repository names are canonically lowercase, but the `scope` exposed to
+        // clients comes from the image's `Vendor` annotation, which preserves the
+        // publisher's display casing (e.g. `SundaeSwap-finance`). Lowercase both path
+        // components so the lookup matches the stored repo regardless of how the
+        // caller cased the scope/name.
+        let repo = format!("{}/{}", scope.to_lowercase(), name.to_lowercase());
 
         let registry_api = oci::get_registry_api_url();
         let query_param = format!(r#"

--- a/frontend/app/routes/protocol_.$scope.$name.tsx
+++ b/frontend/app/routes/protocol_.$scope.$name.tsx
@@ -57,7 +57,7 @@ async function checkRpcDocs(protocolName: string): Promise<string | null> {
 }
 
 export async function loader({ context, params }: Route.LoaderArgs) {
-  const id = `${params.name}/${params.scope}`;
+  const id = `${params.scope}/${params.name}`;
 
   const [result, rpcDocsUrl] = await Promise.all([
     context.queryClient.fetchQuery({


### PR DESCRIPTION
## Problem

The `sundae-v3` protocol breaks the protocol detail page: clicking it from the catalogue bounces straight back to `/protocols` instead of rendering.

`sundae-v3` is the first protocol published under a scope whose display casing differs from its OCI repository name:

| field | value | source |
|---|---|---|
| `id` (repo) | `sundaeswap-finance/sundae-v3` | OCI repo name (canonically lowercase) |
| `scope` | `SundaeSwap-finance` | image `Vendor` annotation (display casing) |

The failure chain:

1. The catalogue links to `/protocol/${protocol.scope}/${protocol.name}` → `/protocol/SundaeSwap-finance/sundae-v3`.
2. The detail loader queries `protocol(scope: "SundaeSwap-finance", name: "sundae-v3")`.
3. The `protocol` resolver built the Zot repo path by interpolating the caller-supplied scope verbatim → `SundaeSwap-finance/sundae-v3`, which doesn't exist (OCI repos are lowercase) → returns `null`.
4. The loader sees `!result.protocol` and does `throw redirect('/protocols')`.

Every other protocol is published under `open-tx3` (already lowercase), so vendor == repo namespace and nothing breaks.

## Fix

- **`backend/src/schema/protocol/query.rs`** — lowercase both path components when building the OCI repo path in the `protocol` resolver, so the lookup matches the stored repo regardless of how the caller cased the scope/name. The returned fields keep their display casing.
- **`frontend/app/routes/protocol_.$scope.$name.tsx`** — fix the detail loader's React Query cache key, which had `name`/`scope` reversed relative to the backend's `scope/name` id (latent, harmless; fixed in passing).

## Verification

Ran the fixed backend binary locally against the live `oci.tx3.land` registry:

- `protocol(scope: "SundaeSwap-finance", name: "sundae-v3")` → resolves fully (all 7 transactions, display casing preserved). Previously `null`.
- `protocol(scope: "open-tx3", name: "indigo")` → still resolves (no regression for lowercase scopes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)