### PR TITLE
fix: resolve protocol logo case-insensitively against OCI scope

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -36,7 +36,11 @@ async fn protocol_logo(
     scope: &str,
     name: &str,
 ) -> Result<(ContentType, Vec<u8>), Status> {
-    let repo = format!("{}/{}", scope, name);
+    // OCI repository names are canonically lowercase, but the scope reaching this
+    // handler comes from the client (ultimately the image's `Vendor` annotation,
+    // which preserves the publisher's display casing, e.g. `SundaeSwap-finance`).
+    // Lowercase both path components so the lookup matches the stored repo.
+    let repo = format!("{}/{}", scope.to_lowercase(), name.to_lowercase());
     let tag = match oci::newest_tag(&repo).await {
         Ok(Some(tag)) => tag,
         Ok(None) => return Err(Status::NotFound),


### PR DESCRIPTION
## Problem

Follow-up to #27. That PR fixed the `protocol` query resolver, which restored the `sundae-v3` detail page — but the protocol **logo** still doesn't render (placeholder initials show instead).

`protocol_logo` (a separate Rocket route in `main.rs`) has the same bug #27 fixed: it built the Zot repo path from the caller-supplied scope verbatim:

```rust
let repo = format!("{}/{}", scope, name);
```

The scope reaching the handler comes from the image's `Vendor` annotation, which preserves the publisher's display casing (`SundaeSwap-finance`). OCI repository names are canonically lowercase (`sundaeswap-finance/sundae-v3`), so `newest_tag` missed the repo and returned `None` → **404**. The frontend's `<img onError>` then falls back to the initials placeholder, so the published logo never renders.

The logo layer itself is present and valid — this is purely the casing mismatch.

## Fix

Lowercase both path components in `protocol_logo`, matching the fix applied to the `protocol` resolver in #27.

## Verification

Ran the backend locally against the live `oci.tx3.land` registry:

| request | before | after |
|---|---|---|
| `GET /protocols/SundaeSwap-finance/sundae-v3/logo` | `404` | `200` `image/png` (6368 B) |
| `GET /protocols/sundaeswap-finance/sundae-v3/logo` | `200` | `200` |
| `GET /protocols/open-tx3/indigo/logo` (regression) | `200` | `200` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)