### PR TITLE
fix(docker): copy backend assets so font include_bytes! resolves

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -8,6 +8,8 @@ RUN apt install -y build-essential pkg-config libssl-dev cmake
 COPY ./backend/Cargo.toml ./backend/Cargo.toml
 COPY ./backend/Cargo.lock ./backend/Cargo.lock
 COPY ./backend/src ./backend/src
+# Fonts baked into the binary via `include_bytes!` (see og_card.rs) — required at build time.
+COPY ./backend/assets ./backend/assets
 
 WORKDIR /app/backend
 


### PR DESCRIPTION
## Problem

The backend Docker image build (`docker/Dockerfile.backend`) fails:

```
error: couldn't read .../assets/fonts/Inter-Regular.ttf: No such file or directory
```

`backend/src/og_card.rs` bakes the Inter fonts into the binary at compile time:

```rust
const INTER_REGULAR: &[u8] = include_bytes!("../assets/fonts/Inter-Regular.ttf");
const INTER_SEMIBOLD: &[u8] = include_bytes!("../assets/fonts/Inter-SemiBold.ttf");
```

But the Dockerfile only copies `Cargo.toml`, `Cargo.lock`, and `src/` into the build stage — never `backend/assets/` — so `cargo build --release` can't find the fonts. This is a latent bug from the OG-card feature (#30); local `cargo build` works because the assets are present in the workspace.

## Fix

Copy `backend/assets` into the build stage:

```dockerfile
COPY ./backend/assets ./backend/assets
```