### PR TITLE
Use CardanoSigner in SDK quickstart guides

### DIFF
--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
@@ -61,7 +61,7 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
     'ctx := context.Background()',
     ...clientOptionsBlock(trp),
     '',
-    'mySigner, err := signer.Ed25519FromHex("addr_test1...", "deadbeef...")',
+    'mySigner, err := signer.CardanoSignerFromHex("addr_test1...", "deadbeef...")',
     'if err != nil {',
     '    log.Fatal(err)',
     '}',

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
@@ -44,10 +44,10 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
   return [
     `from ${module} import Client${hasProfiles ? ', Profile' : ''}`,
     'from tx3_sdk import Party',
-    'from tx3_sdk.signer import Ed25519Signer',
+    'from tx3_sdk.signer import CardanoSigner',
     'from tx3_sdk.trp.client import ClientOptions',
     '',
-    'signer = Ed25519Signer.from_hex("addr_test1...", "deadbeef...")',
+    'signer = CardanoSigner.from_hex("addr_test1...", "deadbeef...")',
     '',
     `client = Client(${clientOptionsLiteral(trp)}${profileArg})`,
     ...partyLines,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
@@ -55,12 +55,12 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
   const lines: string[] = [
     `use ${crate}::Client;`,
     'use tx3_sdk::Party;',
-    'use tx3_sdk::signer::Ed25519Signer;',
+    'use tx3_sdk::signer::CardanoSigner;',
     'use tx3_sdk::trp::ClientOptions;',
     '',
     ...clientOptionsBlock(trp),
     '',
-    'let signer = Ed25519Signer::from_hex("addr_test1...", "deadbeef...")?;',
+    'let signer = CardanoSigner::from_hex("addr_test1...", "deadbeef...")?;',
     '',
   ];
   if (partyLines.length === 0) {

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
@@ -41,9 +41,9 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
 
   const lines: string[] = [
     `import { Client } from "./gen/typescript/${protocol.name}";`,
-    'import { Ed25519Signer, Party } from "tx3-sdk";',
+    'import { CardanoSigner, Party } from "tx3-sdk";',
     '',
-    'const signer = Ed25519Signer.fromHex("addr_test1...", "deadbeef...");',
+    'const signer = await CardanoSigner.fromHex("addr_test1...", "deadbeef...");',
     '',
   ];
   if (partyLines.length === 0) {


### PR DESCRIPTION
## What

The protocol details **SDKs** tab quickstart guides generated example code using `Ed25519Signer`. This switches all four language snippets to `CardanoSigner` — the signer users actually want for Cardano wallets (BIP32-Ed25519 derivation at `m/1852'/1815'/0'/0/0`).

## Changes

All four renderers in `frontend/app/pages/protocol/details/tab/sdks/quick-start/`:

| SDK | Before | After |
|-----|--------|-------|
| TypeScript | `Ed25519Signer.fromHex(...)` | `await CardanoSigner.fromHex(...)` |
| Python | `from tx3_sdk.signer import Ed25519Signer` | `from tx3_sdk.signer import CardanoSigner` |
| Rust | `tx3_sdk::signer::Ed25519Signer::from_hex(...)?` | `tx3_sdk::signer::CardanoSigner::from_hex(...)?` |
| Go | `signer.Ed25519FromHex(...)` | `signer.CardanoSignerFromHex(...)` |

The web SDK's `CardanoSigner.fromHex` is `async` (it derives keys), so the TypeScript snippet now `await`s it. The Python/Rust/Go constructors are synchronous, so those are name-only swaps. Each `CardanoSigner` is already exported from its SDK with matching `from_hex`/`from_mnemonic` constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)