### PR TITLE
Link to install docs in SDK quickstart setup

### DIFF
--- a/frontend/app/pages/protocol/details/tab/sdks.tsx
+++ b/frontend/app/pages/protocol/details/tab/sdks.tsx
@@ -152,7 +152,20 @@ function SetupSection({ steps }: SetupSectionProps) {
             {step.note && (
               <p className="text-zinc-400 text-sm">{step.note}</p>
             )}
-            <CodeBlock lang={step.lang} code={step.body} className={codeBlockClasses} />
+            {step.kind === 'link' && step.href
+              ? (
+                <a
+                  href={step.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex w-fit items-center rounded-md border border-zinc-800 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-900"
+                >
+                  {step.body}
+                </a>
+              )
+              : (
+                <CodeBlock lang={step.lang} code={step.body} className={codeBlockClasses} />
+              )}
           </li>
         ))}
       </ol>

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -20,10 +20,13 @@ export interface QuickStartTx {
 
 export interface SetupStep {
   // `kind` describes intent for the reader; `lang` drives syntax highlighting.
-  kind: 'shell' | 'toml';
+  // 'link' steps point the reader at external docs instead of inlining commands;
+  // they render `body` as the link text to `href` and ignore `lang`.
+  kind: 'shell' | 'toml' | 'link';
   lang: SupportedLanguages;
   title: string;
   body: string;
+  href?: string;
   note?: string;
 }
 
@@ -153,11 +156,12 @@ export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] 
   const ref = `${protocol.scope}/${protocol.name}:${protocol.version}`;
   return [
     {
-      kind: 'shell',
+      kind: 'link',
       lang: 'bash',
       title: 'Install the Tx3 toolchain',
-      body: 'brew install txpipe/tap/tx3up && tx3up',
-      note: 'Skip if `trix` is already on your PATH. See https://docs.txpipe.io/tx3/installation for other platforms.',
+      body: 'docs.txpipe.io/tx3/installation ↗',
+      href: 'https://docs.txpipe.io/tx3/installation',
+      note: 'Follow the official installation guide to get `trix` on your PATH. Skip if it is already installed.',
     },
     {
       kind: 'shell',


### PR DESCRIPTION
## What

The first **Setup** step in the protocol SDKs tab quickstart inlined a shell command:

```bash
brew install txpipe/tap/tx3up && tx3up
```

That only covers macOS/Homebrew and duplicates the official installation guide. This replaces it with a link to **https://docs.txpipe.io/tx3/installation**, keeping the docs as the single cross-platform source of truth.

## Changes

- `SetupStep` gains a `'link'` kind (and an optional `href`). Link steps render `body` as the link text pointing at `href`, and ignore `lang`.
- `SetupSection` in `sdks.tsx` renders link steps as an anchor (opens in a new tab) instead of a `CodeBlock`.
- The "Install the Tx3 toolchain" step in `commonSetupSteps` is now a link step.

All other setup steps (`trix use`, `trix codegen`, dependency installs) remain code blocks as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)