### PR TITLE
Point quickstart at generated README instead of inlining install

### DIFF
--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
@@ -2,7 +2,6 @@ import {
   placeholderFor,
   profileSuppliedNames,
   type SdkRenderer,
-  type SetupStep,
   toPascalCase,
   type TrpConfig,
   unboundParties,
@@ -124,17 +123,8 @@ function lifecycle(_protocol: Protocol): string {
   ].join('\n');
 }
 
-const postCodegenInstall: SetupStep = {
-  kind: 'shell',
-  lang: 'bash',
-  title: 'Install the generated client\'s dependencies',
-  body: 'cd gen/go && go mod tidy',
-  note: 'The generated go.mod declares the tx3 go-sdk; `go mod tidy` resolves it.',
-};
-
 export const goRenderer: SdkRenderer = {
   lang: 'go',
-  postCodegenInstall,
   quickStart,
   txBlock,
   lifecycle,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/index.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/index.ts
@@ -49,11 +49,9 @@ export function generateQuickStart(
   const { profile, trp } = options;
   const txs = [...(protocol.transactions ?? [])].sort(byName);
   const renderer = RENDERERS[sdk];
-  const setupSteps = [...commonSetupSteps(sdk, protocol)];
-  if (renderer.postCodegenInstall) setupSteps.push(renderer.postCodegenInstall);
   return {
     lang: renderer.lang,
-    setupSteps,
+    setupSteps: commonSetupSteps(sdk, protocol),
     quickStart: renderer.quickStart(protocol, profile, trp),
     transactions: txs.map(tx => ({
       name: tx.name,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
@@ -2,7 +2,6 @@ import {
   placeholderFor,
   profileSuppliedNames,
   type SdkRenderer,
-  type SetupStep,
   toPascalCase,
   toSnakeCase,
   type TrpConfig,
@@ -91,17 +90,8 @@ function lifecycle(_protocol: Protocol): string {
   ].join('\n');
 }
 
-const postCodegenInstall: SetupStep = {
-  kind: 'shell',
-  lang: 'bash',
-  title: 'Install the generated client\'s dependencies',
-  body: 'cd gen/python && pip install -r requirements.txt',
-  note: 'The generated requirements.txt pins tx3-sdk and its deps.',
-};
-
 export const pythonRenderer: SdkRenderer = {
   lang: 'python',
-  postCodegenInstall,
   quickStart,
   txBlock,
   lifecycle,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
@@ -105,7 +105,6 @@ function lifecycle(_protocol: Protocol): string {
 
 export const rustRenderer: SdkRenderer = {
   lang: 'rust',
-  postCodegenInstall: null,
   quickStart,
   txBlock,
   lifecycle,

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -38,10 +38,6 @@ export interface QuickStartSnippet {
 // Plug a new SDK in by implementing this and registering it in `index.ts`.
 export interface SdkRenderer {
   lang: SupportedLanguages;
-  // Optional follow-up after `trix codegen` to install the dependencies of the
-  // generated client (the codegen output declares its SDK dep — Cargo picks it
-  // up on build, so Rust doesn't need this; npm/pip/go need an explicit step).
-  postCodegenInstall: SetupStep | null;
   quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string;
   txBlock(tx: Tx, protocol: Protocol): string;
   // The sign + submit chain that takes any resolved tx from `txBlock` and pushes
@@ -132,6 +128,21 @@ const OUTPUT_DIR: Record<SDKKey, string> = {
   python: './gen/python',
 };
 
+// Human-readable SDK names, used in prose.
+const LANG_LABEL: Record<SDKKey, string> = {
+  typescript: 'TypeScript',
+  rust: 'Rust',
+  go: 'Go',
+  python: 'Python',
+};
+
+// `trix codegen` writes each protocol's binding into a subfolder named after
+// the protocol (raw name, no casing transform) under the plugin output dir,
+// alongside a README with language-specific usage instructions.
+function generatedReadmePath(lang: SDKKey, protocol: Protocol): string {
+  return `${OUTPUT_DIR[lang]}/${protocol.name}/README.md`;
+}
+
 export function bindingPlugin(lang: SDKKey): string {
   return CODEGEN_PLUGIN[lang];
 }
@@ -148,7 +159,7 @@ export function outputDir(lang: SDKKey): string {
   return OUTPUT_DIR[lang];
 }
 
-// Shared install-flow steps. Each renderer prepends its own SDK install step.
+// Shared install-flow steps, covering every SDK end to end.
 export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] {
   const ref = `${protocol.scope}/${protocol.name}:${protocol.version}`;
   return [
@@ -172,6 +183,13 @@ export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] 
       title: 'Generate the client',
       body: `trix codegen --plugin ${CODEGEN_PLUGIN[lang]}`,
       note: `Adds the [[codegen]] entry to trix.toml on first run and writes the typed client (defaults to .tx3/codegen/${CODEGEN_PLUGIN[lang]}/; override with output_dir in trix.toml).`,
+    },
+    {
+      kind: 'shell',
+      lang: 'bash',
+      title: 'Read the generated client\'s README',
+      body: generatedReadmePath(lang, protocol),
+      note: `Open this README for ${LANG_LABEL[lang]}-specific instructions on installing the runtime SDK dependency and using the generated client.`,
     },
   ];
 }

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
@@ -2,7 +2,6 @@ import {
   placeholderFor,
   profileSuppliedNames,
   type SdkRenderer,
-  type SetupStep,
   toCamelCase,
   toPascalCase,
   type TrpConfig,
@@ -85,17 +84,8 @@ function lifecycle(_protocol: Protocol): string {
   ].join('\n');
 }
 
-const postCodegenInstall: SetupStep = {
-  kind: 'shell',
-  lang: 'bash',
-  title: 'Install the generated client\'s dependencies',
-  body: 'cd gen/typescript && npm install',
-  note: 'The generated package.json declares tx3-sdk as a dependency.',
-};
-
 export const typescriptRenderer: SdkRenderer = {
   lang: 'typescript',
-  postCodegenInstall,
   quickStart,
   txBlock,
   lifecycle,


### PR DESCRIPTION
## What

The final **Setup** step in the protocol SDKs tab quickstart inlined a per-language dependency-install command:

- TypeScript: `cd gen/typescript && npm install`
- Python: `cd gen/python && pip install -r requirements.txt`
- Go: `cd gen/go && go mod tidy`
- Rust: *(no step at all)*

These duplicate (and can drift from) the README that `trix codegen` already emits next to the generated client. This replaces them with a single step — shared across all four SDKs — that points the reader at that README for the language-specific instructions.

## Path correctness

`trix codegen` writes each protocol's binding into a subfolder named after the **protocol** (raw name, no casing transform) under the plugin output dir, alongside a `README.md`. The step references that exact path:

```
./gen/<lang>/<protocol-name>/README.md
```

## Changes

- `commonSetupSteps` (in `shared.ts`) gains a final "Read the generated client's README" step, built from a new `generatedReadmePath(lang, protocol)` helper and a `LANG_LABEL` map for the prose.
- Removes the now-unused `postCodegenInstall` field from the `SdkRenderer` interface and its three implementations (`typescript.ts`, `python.ts`, `go.ts`), plus the `postCodegenInstall: null` on the Rust renderer and the conditional push in `index.ts`. Rust now gets the README step too.

Verified locally: `tsc` and eslint pass clean.

> Note: lightly overlaps with #35 (both touch `shared.ts`, but in different regions — interface/install step there vs. README additions here); should merge without conflict in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)