### PR TITLE
Polish quickstart setup steps

### DIFF
--- a/frontend/app/pages/protocol/details/tab/sdks.tsx
+++ b/frontend/app/pages/protocol/details/tab/sdks.tsx
@@ -2,9 +2,11 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import clsx from 'clsx';
 
 // Components
+import { Button } from '~/components/ui/Button';
 import { CodeBlock } from '~/components/ui/CodeBlock';
 import { Dropdown } from '~/components/ui/Dropdown';
 import { ChevronRightIcon } from '~/components/icons/chevron-right';
+import { FileDescriptionIcon } from '~/components/icons/file-description';
 
 // Config
 import { getTrpForProfile, TRP_ENDPOINTS } from '~/trp-config';
@@ -152,7 +154,23 @@ function SetupSection({ steps }: SetupSectionProps) {
             {step.note && (
               <p className="text-zinc-400 text-sm">{step.note}</p>
             )}
-            <CodeBlock lang={step.lang} code={step.body} className={codeBlockClasses} />
+            {step.kind === 'link' && step.href
+              ? (
+                <Button
+                  type="button"
+                  size="s"
+                  variant="outlined"
+                  color="zinc"
+                  className="w-fit rounded-lg"
+                  onClick={() => window.open(step.href, '_blank', 'noopener,noreferrer')}
+                >
+                  <FileDescriptionIcon width="18" height="18" />
+                  {step.body}
+                </Button>
+              )
+              : (
+                <CodeBlock lang={step.lang} code={step.body} className={codeBlockClasses} />
+              )}
           </li>
         ))}
       </ol>

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -143,8 +143,8 @@ const LANG_LABEL: Record<SDKKey, string> = {
 // `trix codegen` writes each protocol's binding into a subfolder named after
 // the protocol (raw name, no casing transform) under the plugin output dir,
 // alongside a README with language-specific usage instructions.
-function generatedReadmePath(lang: SDKKey, protocol: Protocol): string {
-  return `${OUTPUT_DIR[lang]}/${protocol.name}/README.md`;
+function generatedOutputDir(lang: SDKKey, protocol: Protocol): string {
+  return `${OUTPUT_DIR[lang]}/${protocol.name}`;
 }
 
 export function bindingPlugin(lang: SDKKey): string {
@@ -187,14 +187,7 @@ export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] 
       lang: 'bash',
       title: 'Generate the client',
       body: `trix codegen --plugin ${CODEGEN_PLUGIN[lang]}`,
-      note: `Adds the [[codegen]] entry to trix.toml on first run and writes the typed client (defaults to .tx3/codegen/${CODEGEN_PLUGIN[lang]}/; override with output_dir in trix.toml).`,
-    },
-    {
-      kind: 'shell',
-      lang: 'bash',
-      title: 'Read the generated client\'s README',
-      body: generatedReadmePath(lang, protocol),
-      note: `Open this README for ${LANG_LABEL[lang]}-specific instructions on installing the runtime SDK dependency and using the generated client.`,
+      note: `Adds the [[codegen]] entry to trix.toml on first run and writes the typed client to ${generatedOutputDir(lang, protocol)}/. Open the README there for ${LANG_LABEL[lang]}-specific instructions on installing the runtime SDK and using the client.`,
     },
   ];
 }

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -20,10 +20,14 @@ export interface QuickStartTx {
 
 export interface SetupStep {
   // `kind` describes intent for the reader; `lang` drives syntax highlighting.
-  kind: 'shell' | 'toml';
+  // 'shell'/'toml' render `body` as a code block. 'link' renders `body` as the
+  // label of a button that opens `href` — used to defer to external docs
+  // instead of inlining commands.
+  kind: 'shell' | 'toml' | 'link';
   lang: SupportedLanguages;
   title: string;
   body: string;
+  href?: string;
   note?: string;
 }
 
@@ -164,11 +168,12 @@ export function commonSetupSteps(lang: SDKKey, protocol: Protocol): SetupStep[] 
   const ref = `${protocol.scope}/${protocol.name}:${protocol.version}`;
   return [
     {
-      kind: 'shell',
+      kind: 'link',
       lang: 'bash',
       title: 'Install the Tx3 toolchain',
-      body: 'brew install txpipe/tap/tx3up && tx3up',
-      note: 'Skip if `trix` is already on your PATH. See https://docs.txpipe.io/tx3/installation for other platforms.',
+      body: 'Read the installation guide',
+      href: 'https://docs.txpipe.io/tx3/installation',
+      note: 'Install `trix` for your platform by following the official guide. Skip if it is already on your PATH.',
     },
     {
       kind: 'shell',


### PR DESCRIPTION
## What

Two cleanups to the **Setup** steps in the protocol SDKs tab quickstart.

### 1. Install step → docs button (replaces #35)

The first step inlined a Homebrew-only command (`brew install txpipe/tap/tx3up && tx3up`), which only covers macOS and duplicates the official guide. It now shows an outlined **📄 Read the installation guide** button that opens https://docs.txpipe.io/tx3/installation in a new tab — reusing the exact design-system pattern the Deploy tab already uses for its "Read the docs" button (`deploy.tsx`). No snippet, no raw URL.

### 2. README pointer → help text on the codegen step

The standalone "Read the generated client's README" step (added in #36) rendered the README *path* in a code block — a snippet for something that isn't a command. Dropped it and folded the guidance into the help text (`note`) of the preceding "Generate the client" step, which already explains the output folder:

> Adds the [[codegen]] entry to trix.toml on first run and writes the typed client to `./gen/<lang>/<protocol>/`. Open the README there for `<Lang>`-specific instructions on installing the runtime SDK and using the client.

## Changes

- `SetupStep` gains a `'link'` kind (+ optional `href`). Link steps render `body` as a `Button` label pointing at `href`; `SetupSection` renders them via the design-system `Button` (`variant="outlined"`, `color="zinc"`, `FileDescriptionIcon`, `window.open(..., '_blank', 'noopener,noreferrer')`).
- `commonSetupSteps`: install step becomes a link step; the separate README step is removed and its guidance merged into the codegen step's note (via a `generatedOutputDir` helper).

Verified locally: `tsc` and eslint pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)