### PR TITLE
feat: handle BuiltInOp::Mul in ast_to_svg

### DIFF
--- a/backend/src/ast_to_svg.rs
+++ b/backend/src/ast_to_svg.rs
@@ -251,6 +251,7 @@ pub(crate) fn extract_party_from_expr(expr: &tir::Expression) -> Option<String> 
             tir::BuiltInOp::NoOp(e) | tir::BuiltInOp::Negate(e) => extract_party_from_expr(e),
             tir::BuiltInOp::Add(a, b)
             | tir::BuiltInOp::Sub(a, b)
+            | tir::BuiltInOp::Mul(a, b)
             | tir::BuiltInOp::Concat(a, b)
             | tir::BuiltInOp::Property(a, b) => {
                 extract_party_from_expr(a).or_else(|| extract_party_from_expr(b))


### PR DESCRIPTION
## Summary

Handles the new `tx3-tir` `BuiltInOp::Mul` variant in the backend's SVG renderer.

`extract_party_from_expr` matches `BuiltInOp` exhaustively; this adds `Mul` to the existing `Add | Sub | Concat | Property` two-operand arm (recurse into both operands). Required for the backend to compile once `tx3-tir` is bumped to the version that adds `Mul`.

## Depends on

tx3-lang/tir#1. Bump `tx3-tir` to the release that includes `Mul` before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
