### PR TITLE
feat: handle Div in BuiltInOp party extraction

### DIFF
--- a/backend/src/ast_to_svg.rs
+++ b/backend/src/ast_to_svg.rs
@@ -252,6 +252,7 @@ pub(crate) fn extract_party_from_expr(expr: &tir::Expression) -> Option<String> 
             tir::BuiltInOp::Add(a, b)
             | tir::BuiltInOp::Sub(a, b)
             | tir::BuiltInOp::Mul(a, b)
+            | tir::BuiltInOp::Div(a, b)
             | tir::BuiltInOp::Concat(a, b)
             | tir::BuiltInOp::Property(a, b) => {
                 extract_party_from_expr(a).or_else(|| extract_party_from_expr(b))


### PR DESCRIPTION
## Summary

Adds the `tir::BuiltInOp::Div(a, b)` arm to `extract_party_from_expr` (`backend/src/ast_to_svg.rs`), joining the existing two-operand `Add | Sub | Mul | Concat | Property` arm. Mechanical update for the new `/` operator — recurses into both operands like the others.

## Dependency note

Requires the `Div` variant from **tx3-lang/tir**; bump `tx3-tir` (and `tx3-lang`) here once those release. Verified compiling via a local path patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)