### PR TITLE
chore: bump tx3 deps for parametric tuple types

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -3669,9 +3669,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-lang"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95c2ad1c448f7b7e79f267a4bdba93ee1eb67047988d59eb0d072bab66499aa1"
+checksum = "9d34a4052a26da8967187bec9be032233a231770d43569043aaf87f8d3e9f54e"
 dependencies = [
  "ciborium",
  "hex",
@@ -3710,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-tir"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e332c5ab744e8f17d54dfa4b6e3e177d5055141a1f37625303d4613277a72"
+checksum = "4bd8b43d04c3d116e901407cf4c6fa4949938f8904dddf7088cb97efcacd8bb2"
 dependencies = [
  "ciborium",
  "hex",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -23,7 +23,7 @@ rocket = "0.5.1"
 rocket_cors = "0.6.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-tx3-lang = "0.21.0"
-tx3-tir = "0.17.0"
+tx3-lang = "0.22.0"
+tx3-tir = "0.18.0"
 urlencoding = "2.1.3"
 uuid = { version = "1.11.0", features = ["v4"] }

--- a/tracker/Cargo.lock
+++ b/tracker/Cargo.lock
@@ -3671,7 +3671,7 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 [[package]]
 name = "tx3-lift"
 version = "0.1.0"
-source = "git+https://github.com/tx3-lang/tx3-lift?rev=04d0b90a34b2461dd497f9941b491aed5d925bfd#04d0b90a34b2461dd497f9941b491aed5d925bfd"
+source = "git+https://github.com/tx3-lang/tx3-lift?rev=e8c91bf652fe8558eae761c2d9509d518b952b89#e8c91bf652fe8558eae761c2d9509d518b952b89"
 dependencies = [
  "bech32 0.11.1",
  "hex",
@@ -3686,7 +3686,7 @@ dependencies = [
 [[package]]
 name = "tx3-lift-cardano"
 version = "0.1.0"
-source = "git+https://github.com/tx3-lang/tx3-lift?rev=04d0b90a34b2461dd497f9941b491aed5d925bfd#04d0b90a34b2461dd497f9941b491aed5d925bfd"
+source = "git+https://github.com/tx3-lang/tx3-lift?rev=e8c91bf652fe8558eae761c2d9509d518b952b89#e8c91bf652fe8558eae761c2d9509d518b952b89"
 dependencies = [
  "hex",
  "pallas",
@@ -3755,9 +3755,9 @@ dependencies = [
 
 [[package]]
 name = "tx3-tir"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "152e332c5ab744e8f17d54dfa4b6e3e177d5055141a1f37625303d4613277a72"
+checksum = "4bd8b43d04c3d116e901407cf4c6fa4949938f8904dddf7088cb97efcacd8bb2"
 dependencies = [
  "ciborium",
  "hex",

--- a/tracker/Cargo.toml
+++ b/tracker/Cargo.toml
@@ -15,9 +15,9 @@ name = "tracker"
 path = "src/main.rs"
 
 [dependencies]
-tx3-lift         = { git = "https://github.com/tx3-lang/tx3-lift", rev = "04d0b90a34b2461dd497f9941b491aed5d925bfd" }
-tx3-lift-cardano = { git = "https://github.com/tx3-lang/tx3-lift", rev = "04d0b90a34b2461dd497f9941b491aed5d925bfd" }
-tx3-tir          = "0.17.0"
+tx3-lift         = { git = "https://github.com/tx3-lang/tx3-lift", rev = "e8c91bf652fe8558eae761c2d9509d518b952b89" }
+tx3-lift-cardano = { git = "https://github.com/tx3-lang/tx3-lift", rev = "e8c91bf652fe8558eae761c2d9509d518b952b89" }
+tx3-tir          = "0.18.0"
 tx3-sdk          = "0.11.0"
 pallas           = "1.0.0"
 


### PR DESCRIPTION
## Summary

Picks up the released parametric tuple types across the registry crates:

- **backend** — `tx3-lang` `0.21.0` -> `0.22.0`, `tx3-tir` `0.17.0` -> `0.18.0`.
- **tracker** — `tx3-tir` `0.17.0` -> `0.18.0`, and advances the `tx3-lift` git rev to `e8c91bf` (its own tir 0.18 bump). The old rev pulled `tx3-tir 0.17`, which conflicted with the direct 0.18 dep (two incompatible tir copies -> trait-impl mismatches); aligning the rev resolves to a single `tx3-tir 0.18.0`.

## Verification

Both crates build against the new versions. backend's `sqlx-postgres` integration tests require `DATABASE_URL` (a live Postgres) and are environmental — unaffected by this change.

## Release ordering

Follows the `tx3-lang 0.22.0` / `tx3-tir 0.18.0` releases and the merged `tx3-lift` #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)