### PR TITLE
fix: registry UX truthfulness — try-out gating, snippet correctness, stable ordering, homepage, ref discovery

### DIFF
--- a/backend/src/schema/protocol/mod.rs
+++ b/backend/src/schema/protocol/mod.rs
@@ -56,6 +56,10 @@ pub struct Protocol {
     name: String,
     scope: String,
     repository_url: Option<String>,
+    /// Project homepage, read from the `org.opencontainers.image.url`
+    /// annotation of the published OCI manifest. Populated on the detail
+    /// query (which pulls the manifest); `None` on list queries.
+    homepage_url: Option<String>,
     published_date: i64,
     version: String,
     readme: Option<String>,
@@ -131,21 +135,31 @@ pub struct Tx {
 
 #[ComplexObject]
 impl Protocol {
+    /// Transactions in a stable order (sorted by name). The TII stores them in
+    /// a map, whose iteration order must never leak into the API: it would
+    /// reshuffle the UI on every load.
     async fn transactions(&self) -> Vec<Tx> {
-        if let Some(tii) = &self.tii {
-            return self.transactions_from_tii(tii);
-        }
+        let mut txs = if let Some(tii) = &self.tii {
+            self.transactions_from_tii(tii)
+        } else {
+            self.transactions_from_source()
+        };
 
-        self.transactions_from_source()
+        txs.sort_by(|a, b| a.name.cmp(&b.name));
+        txs
     }
 
+    /// Parties in a stable order (sorted by name); see [`Self::transactions`].
     async fn parties(&self) -> Vec<Party> {
         let Some(tii) = &self.tii else { return vec![] };
 
-        tii.parties.iter().map(|(name, party)| Party {
+        let mut parties: Vec<Party> = tii.parties.iter().map(|(name, party)| Party {
             name: name.clone(),
             description: party.description.clone(),
-        }).collect()
+        }).collect();
+
+        parties.sort_by(|a, b| a.name.cmp(&b.name));
+        parties
     }
 
     async fn profiles(&self) -> Vec<Profile> {

--- a/backend/src/schema/protocol/query.rs
+++ b/backend/src/schema/protocol/query.rs
@@ -85,6 +85,16 @@ pub async fn build_protocol(resolved: ResolvedProtocol) -> Result<(Protocol, Ima
     let tii = oci::get_tii(&oci_image)
         .and_then(|json| serde_json::from_str::<TiiFile>(&json).ok());
 
+    // The project homepage travels as the standard OCI `url` annotation on the
+    // published manifest (`trix publish` maps `[protocol].homepage` to it).
+    // The zot search summary does not surface it, but the full pull does.
+    let homepage_url = oci_image
+        .manifest
+        .as_ref()
+        .and_then(|m| m.annotations.as_ref())
+        .and_then(|a| a.get("org.opencontainers.image.url"))
+        .cloned();
+
     let published_date = if let Some(published_date) = image.last_updated {
         chrono::DateTime::parse_from_rfc3339(&published_date)
             .unwrap()
@@ -97,6 +107,7 @@ pub async fn build_protocol(resolved: ResolvedProtocol) -> Result<(Protocol, Ima
         name: image.title.unwrap_or_default(),
         scope: image.vendor.unwrap_or_default(),
         repository_url: image.source,
+        homepage_url,
         description: image.description,
         published_date,
         source,
@@ -196,6 +207,9 @@ impl ProtocolQuery {
                             scope: image.vendor.clone().unwrap_or_default(),
                             version: image.tag.clone().unwrap_or_default(),
                             repository_url: image.source.clone(),
+                            // Not in the zot search summary; only the detail
+                            // query (full manifest pull) can populate it.
+                            homepage_url: None,
                             description: image.description.clone(),
                             published_date,
                             source,

--- a/frontend/@types/graphql.d.ts
+++ b/frontend/@types/graphql.d.ts
@@ -95,8 +95,15 @@ interface ProfileParty {
 interface Protocol {
   description: Maybe<Scalars['String']['output']>;
   environment: Array<EnvironmentParam>;
+  /**
+   * Project homepage, read from the `org.opencontainers.image.url`
+   * annotation of the published OCI manifest. Populated on the detail
+   * query (which pulls the manifest); `None` on list queries.
+   */
+  homepageUrl: Maybe<Scalars['String']['output']>;
   id: Scalars['ID']['output'];
   name: Scalars['String']['output'];
+  /** Parties in a stable order (sorted by name); see [`Self::transactions`]. */
   parties: Array<Party>;
   profiles: Array<Profile>;
   publishedDate: Scalars['Int']['output'];
@@ -104,6 +111,11 @@ interface Protocol {
   repositoryUrl: Maybe<Scalars['String']['output']>;
   scope: Scalars['String']['output'];
   source: Maybe<Scalars['String']['output']>;
+  /**
+   * Transactions in a stable order (sorted by name). The TII stores them in
+   * a map, whose iteration order must never leak into the API: it would
+   * reshuffle the UI on every load.
+   */
   transactions: Array<Tx>;
   version: Scalars['String']['output'];
 }

--- a/frontend/app/components/icons/world.tsx
+++ b/frontend/app/components/icons/world.tsx
@@ -1,0 +1,23 @@
+import type { SVGProps } from 'react';
+
+// Tabler Icons world
+export function WorldIcon({ strokeWidth = 1.5, ...props }: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      viewBox="0 0 24 24"
+      strokeWidth={strokeWidth}
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" />
+      <path d="M3 12a9 9 0 1 0 18 0 9 9 0 1 0-18 0" />
+      <path d="M3.6 9h16.8M3.6 15h16.8M11.5 3a17 17 0 0 0 0 18M12.5 3a17 17 0 0 1 0 18" />
+    </svg>
+  );
+}

--- a/frontend/app/gql/protocols.query.ts
+++ b/frontend/app/gql/protocols.query.ts
@@ -84,6 +84,7 @@ export const DETAIL_QUERY = gql`
       version
       publishedDate
       repositoryUrl
+      homepageUrl
       readme
       description
       source

--- a/frontend/app/lib/tracker/lifted.ts
+++ b/frontend/app/lib/tracker/lifted.ts
@@ -11,9 +11,21 @@ export interface LiftedParty {
   readonly role: string;
 }
 
+export interface LiftedReference {
+  readonly name: string;
+  /** UTxO reference as `txhash#index`, lowercase hex. */
+  readonly ref: string;
+}
+
 export interface Lifted {
   readonly txName: string;
   readonly parties: Record<string, LiftedParty>;
+  /**
+   * Reference inputs of the matched transaction. This is how callers discover
+   * the concrete UTxO refs a protocol expects as parameters (e.g. bodega's
+   * `project_info_ref`): the values real on-chain transactions used.
+   */
+  readonly references: LiftedReference[];
   readonly raw: string;
 }
 
@@ -46,9 +58,15 @@ interface RawLiftedParty {
   role?: unknown;
 }
 
+interface RawLiftedReference {
+  tir_input_name?: unknown;
+  utxo_ref?: unknown;
+}
+
 interface RawLifted {
   tx_name?: unknown;
   parties?: Record<string, unknown>;
+  references?: unknown;
 }
 
 /**
@@ -73,5 +91,26 @@ export function parseLifted(json: string): Lifted {
     }
   }
 
-  return { txName, parties, raw: json };
+  // The tracker writes a reference input as
+  // `{ tir_input_name, utxo_ref: [[...tx hash bytes], index], ... }`.
+  const references: LiftedReference[] = [];
+  if (Array.isArray(data.references)) {
+    for (const value of data.references) {
+      if (!value || typeof value !== 'object') continue;
+      const entry = value as RawLiftedReference;
+      if (!Array.isArray(entry.utxo_ref) || entry.utxo_ref.length !== 2) continue;
+      const [hash, index] = entry.utxo_ref as [unknown, unknown];
+      if (!Array.isArray(hash) || typeof index !== 'number') continue;
+      try {
+        references.push({
+          name: typeof entry.tir_input_name === 'string' ? entry.tir_input_name : '',
+          ref: `${bytesToHex(hash as number[])}#${index}`,
+        });
+      } catch {
+        // malformed byte array — skip this entry, keep the rest
+      }
+    }
+  }
+
+  return { txName, parties, references, raw: json };
 }

--- a/frontend/app/pages/protocol/details/info.tsx
+++ b/frontend/app/pages/protocol/details/info.tsx
@@ -2,6 +2,7 @@ import clsx from 'clsx';
 import dayjs from 'dayjs';
 
 import { GitIcon } from '~/components/icons/git';
+import { WorldIcon } from '~/components/icons/world';
 
 interface Props {
   className?: string;
@@ -26,6 +27,16 @@ export function Info({ protocol, className }: Props) {
         <p className="text-zinc-500">Published by</p>
         <p className="mt-2 text-lg text-primary-600">@{protocol.scope}</p>
       </div>
+
+      {protocol.homepageUrl && (
+        <div>
+          <p className="text-zinc-500">Homepage</p>
+          <a href={protocol.homepageUrl} className="w-fit mt-2 text-zinc-100 flex items-center gap-2" target="_blank" rel="noreferrer">
+            <WorldIcon width="20" height="20" />
+            <span className="underline">{protocol.homepageUrl.replace(/http(s)?:\/\//i, '').replace(/\/$/, '')}</span>
+          </a>
+        </div>
+      )}
 
       {protocol.repositoryUrl && (
         <div>

--- a/frontend/app/pages/protocol/details/tab/activity.tsx
+++ b/frontend/app/pages/protocol/details/tab/activity.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Link, useFetcher, useSearchParams } from 'react-router';
 import { type darkStyles, JsonView } from 'react-json-view-lite';
 
-import { parseLifted, truncateHex } from '~/lib/tracker/lifted';
+import { type LiftedReference, parseLifted, truncateHex } from '~/lib/tracker/lifted';
 import { useFetcherPolling } from '~/hooks/useFetcherPolling';
 import { PartyChip } from './activity/PartyChip';
 import { TxNamePill } from './activity/TxNamePill';
@@ -326,7 +326,7 @@ function DetailView({ match, hash, loading }: { match: Match | null; hash: strin
     );
   }
 
-  const { parties } = parseLifted(match.lifted);
+  const { parties, references } = parseLifted(match.lifted);
 
   return (
     <div className="space-y-6">
@@ -334,6 +334,7 @@ function DetailView({ match, hash, loading }: { match: Match | null; hash: strin
       <article className="space-y-8">
         <DetailHeader match={match} />
         <PartiesSection parties={parties} />
+        <ReferencesSection references={references} />
         <RawLiftedDetails rawLifted={match.lifted} />
       </article>
     </div>
@@ -385,6 +386,32 @@ function PartiesSection({ parties }: { parties: Record<string, { address: string
             ))}
           </div>
         )}
+    </section>
+  );
+}
+
+// Reference inputs of the matched transaction, as `txhash#index`. This is the
+// discovery surface for ref-UTxO parameters (e.g. bodega's `project_info_ref`):
+// callers can read the concrete values real on-chain transactions used.
+function ReferencesSection({ references }: { references: LiftedReference[]; }) {
+  if (references.length === 0) return null;
+
+  return (
+    <section className="space-y-3">
+      <h3 className="text-sm font-semibold text-zinc-400 uppercase tracking-wider">
+        Reference inputs ({references.length})
+      </h3>
+      <div className="rounded-md border border-zinc-800 bg-zinc-950 overflow-hidden">
+        {references.map((reference, i) => (
+          <div
+            key={`${reference.name}-${i}`}
+            className="px-4 py-2.5 border-b last:border-b-0 border-zinc-800/50 flex flex-col sm:flex-row sm:items-baseline gap-1 sm:gap-0"
+          >
+            <span className="sm:w-40 text-zinc-400 font-mono text-sm break-all">{reference.name || '—'}</span>
+            <span className="flex-1 font-mono text-sm text-zinc-50 break-all select-all">{reference.ref}</span>
+          </div>
+        ))}
+      </div>
     </section>
   );
 }

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/go.ts
@@ -4,7 +4,7 @@ import {
   type SdkRenderer,
   toPascalCase,
   type TrpConfig,
-  unboundParties,
+  unboundPartyBindings,
   userProvidedParams,
 } from './shared';
 
@@ -33,14 +33,14 @@ function clientOptionsBlock(trp: TrpConfig): string[] {
 function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string {
   const hasProfiles = (protocol.profiles ?? []).length > 0;
   const supplied = profileSuppliedNames(profile);
-  const unbound = unboundParties(protocol, supplied);
+  const unbound = unboundPartyBindings(protocol, profile, supplied);
   const profileArg = hasProfiles && profile
     ? `, protocol.Profile${toPascalCase(profile.name)}`
     : '';
 
-  const partyLines = unbound.map((p, i) => {
+  const partyLines = unbound.map(p => {
     const setter = `With${toPascalCase(p.name)}`;
-    if (i === 0) {
+    if (p.kind === 'signer') {
       return `    .${setter}(facade.SignerParty(signer))`;
     }
     return `    .${setter}(facade.AddressParty(${JSON.stringify(p.address)}))`;
@@ -54,7 +54,9 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
     '    "github.com/tx3-lang/go-sdk/sdk/facade"',
     '    "github.com/tx3-lang/go-sdk/sdk/signer"',
     '    "github.com/tx3-lang/go-sdk/sdk/trp"',
-    '    "./gen/go/protocol"',
+    '',
+    '    // The generated module; its package name is `protocol`.',
+    `    ${JSON.stringify(`yourapp/${protocol.name}`)}`,
     ')',
     '',
     'ctx := context.Background()',

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/index.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/index.ts
@@ -24,7 +24,11 @@ const RENDERERS: Record<SDKKey, SdkRenderer> = {
   go: goRenderer,
 };
 
-function profileHasData(profile: Profile): boolean {
+// A profile "exists" only when the published `.tii` gives it actual content —
+// party addresses or environment values. Publishers emit empty stubs for every
+// known channel (`profiles.{channel}: { environment: {}, parties: {} }`), so
+// key presence alone would list channels the protocol does not really support.
+export function profileHasData(profile: Profile): boolean {
   if (profile.parties.length > 0) return true;
   if (!profile.environment) return false;
   try {

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/python.ts
@@ -5,12 +5,14 @@ import {
   toPascalCase,
   toSnakeCase,
   type TrpConfig,
-  unboundParties,
+  unboundPartyBindings,
   userProvidedParams,
 } from './shared';
 
+// The generated package is the protocol's own folder (snake_cased so the
+// module name stays a valid Python identifier); there is no `gen.` prefix.
 function pythonModule(protocol: Protocol): string {
-  return `gen.python.${toSnakeCase(protocol.name)}`;
+  return toSnakeCase(protocol.name);
 }
 
 function clientOptionsLiteral(trp: TrpConfig): string {
@@ -27,14 +29,14 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
   const module = pythonModule(protocol);
   const hasProfiles = (protocol.profiles ?? []).length > 0;
   const supplied = profileSuppliedNames(profile);
-  const unbound = unboundParties(protocol, supplied);
+  const unbound = unboundPartyBindings(protocol, profile, supplied);
   const profileArg = hasProfiles && profile
     ? `, Profile.${toSnakeCase(profile.name).toUpperCase()}`
     : '';
 
-  const partyLines = unbound.map((p, i) => {
+  const partyLines = unbound.map(p => {
     const setter = `with_${toSnakeCase(p.name)}`;
-    if (i === 0) {
+    if (p.kind === 'signer') {
       return `client = client.${setter}(Party.signer(signer))`;
     }
     return `client = client.${setter}(Party.address(${JSON.stringify(p.address)}))`;

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/rust.ts
@@ -5,7 +5,7 @@ import {
   toPascalCase,
   toSnakeCase,
   type TrpConfig,
-  unboundParties,
+  unboundPartyBindings,
   userProvidedParams,
 } from './shared';
 
@@ -39,14 +39,14 @@ function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig)
   const crate = cratePath(protocol);
   const hasProfiles = (protocol.profiles ?? []).length > 0;
   const supplied = profileSuppliedNames(profile);
-  const unbound = unboundParties(protocol, supplied);
+  const unbound = unboundPartyBindings(protocol, profile, supplied);
   const profileArg = hasProfiles && profile
     ? `, ${crate}::Profile::${toPascalCase(profile.name)}`
     : '';
 
-  const partyLines = unbound.map((p, i) => {
+  const partyLines = unbound.map(p => {
     const setter = `with_${toSnakeCase(p.name)}`;
-    if (i === 0) {
+    if (p.kind === 'signer') {
       return `    .${setter}(Party::signer(signer))`;
     }
     return `    .${setter}(Party::address(${JSON.stringify(p.address)}))`;

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/shared.ts
@@ -53,18 +53,83 @@ export const byName = <T extends { name: string; }>(a: T, b: T) => a.name.locale
 
 export const PARTY_ADDRESS_PLACEHOLDER = 'addr_test1...';
 
+export type PartyBindingKind = 'signer' | 'address';
+
 export interface PartyBinding {
   name: string;
+  kind: PartyBindingKind;
+  // Meaningful when `kind` is 'address': a concrete address from the profile
+  // env, or a placeholder naming what the caller must provide.
   address: string;
 }
 
+// Script parties (`positionscript`, `commitscript`, ...) are protocol-owned
+// addresses. They must never receive the caller's signer or wallet address.
+export function isScriptParty(name: string): boolean {
+  return /script$/i.test(name);
+}
+
+function normalizeKey(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+const BECH32_ADDRESS = /^(addr|addr_test|stake|stake_test)1[02-9ac-hj-np-z]+$/i;
+
+// Script-party address sourced from the selected profile's environment: an env
+// key matching the party name (optionally suffixed `address`/`addr`) whose
+// value is a bech32 address.
+export function envScriptAddress(profile: Profile | null, partyName: string): string | null {
+  if (!profile?.environment) return null;
+  let env: Record<string, unknown>;
+  try {
+    env = JSON.parse(profile.environment) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  const target = normalizeKey(partyName);
+  for (const [key, value] of Object.entries(env)) {
+    const norm = normalizeKey(key);
+    const matches = norm === target || norm === `${target}address` || norm === `${target}addr`;
+    if (matches && typeof value === 'string' && BECH32_ADDRESS.test(value)) {
+      return value;
+    }
+  }
+  return null;
+}
+
+export function scriptAddressPlaceholder(partyName: string): string {
+  return `<${partyName} script address>`;
+}
+
 // Parties declared by the protocol that the profile does NOT supply — these
-// need a `.with<Name>(...)` call on the generated Client.
-export function unboundParties(protocol: Protocol, supplied: Set<string>): PartyBinding[] {
-  return [...(protocol.parties ?? [])]
+// need a `.with<Name>(...)` call on the generated Client. The signer belongs
+// to the first non-script party (the caller's own wallet, e.g. `user` or
+// `participant`); a script party takes its address from the profile env when
+// one is published, and an explicit script-address placeholder otherwise.
+export function unboundPartyBindings(
+  protocol: Protocol,
+  profile: Profile | null,
+  supplied: Set<string>,
+): PartyBinding[] {
+  const unbound = [...(protocol.parties ?? [])]
     .filter(p => !supplied.has(p.name))
-    .sort(byName)
-    .map(p => ({ name: p.name, address: PARTY_ADDRESS_PLACEHOLDER }));
+    .sort(byName);
+
+  const signerName = unbound.find(p => !isScriptParty(p.name))?.name ?? null;
+
+  return unbound.map(p => {
+    if (p.name === signerName) {
+      return { name: p.name, kind: 'signer' as const, address: '' };
+    }
+    if (isScriptParty(p.name)) {
+      return {
+        name: p.name,
+        kind: 'address' as const,
+        address: envScriptAddress(profile, p.name) ?? scriptAddressPlaceholder(p.name),
+      };
+    }
+    return { name: p.name, kind: 'address' as const, address: PARTY_ADDRESS_PLACEHOLDER };
+  });
 }
 
 export function toCamelCase(name: string): string {
@@ -125,11 +190,14 @@ const CODEGEN_PLUGIN: Record<SDKKey, string> = {
   python: 'python-client',
 };
 
+// Default output dir used by `trix codegen` when the `[[codegen]]` entry sets
+// no explicit `output_dir`: `.tx3/codegen/{plugin}/` (see trix
+// `CodegenConfig::output_dir`).
 const OUTPUT_DIR: Record<SDKKey, string> = {
-  typescript: './gen/typescript',
-  rust: './gen/rust',
-  go: './gen/go',
-  python: './gen/python',
+  typescript: '.tx3/codegen/ts-client',
+  rust: '.tx3/codegen/rust-client',
+  go: '.tx3/codegen/go-client',
+  python: '.tx3/codegen/python-client',
 };
 
 // Human-readable SDK names, used in prose.
@@ -145,22 +213,6 @@ const LANG_LABEL: Record<SDKKey, string> = {
 // alongside a README with language-specific usage instructions.
 function generatedOutputDir(lang: SDKKey, protocol: Protocol): string {
   return `${OUTPUT_DIR[lang]}/${protocol.name}`;
-}
-
-export function bindingPlugin(lang: SDKKey): string {
-  return CODEGEN_PLUGIN[lang];
-}
-
-export function bindingsTomlBlock(lang: SDKKey): string {
-  return [
-    '[[codegen]]',
-    `plugin = ${JSON.stringify(CODEGEN_PLUGIN[lang])}`,
-    `output_dir = ${JSON.stringify(OUTPUT_DIR[lang])}`,
-  ].join('\n');
-}
-
-export function outputDir(lang: SDKKey): string {
-  return OUTPUT_DIR[lang];
 }
 
 // Shared install-flow steps, covering every SDK end to end.

--- a/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
+++ b/frontend/app/pages/protocol/details/tab/sdks/quick-start/typescript.ts
@@ -5,7 +5,7 @@ import {
   toCamelCase,
   toPascalCase,
   type TrpConfig,
-  unboundParties,
+  unboundPartyBindings,
   userProvidedParams,
 } from './shared';
 
@@ -27,19 +27,19 @@ function clientOptionsLiteral(trp: TrpConfig): string {
 function quickStart(protocol: Protocol, profile: Profile | null, trp: TrpConfig): string {
   const hasProfiles = (protocol.profiles ?? []).length > 0;
   const supplied = profileSuppliedNames(profile);
-  const unbound = unboundParties(protocol, supplied);
+  const unbound = unboundPartyBindings(protocol, profile, supplied);
   const profileArg = hasProfiles && profile ? `, ${JSON.stringify(profile.name)}` : '';
 
-  const partyLines = unbound.map((p, i) => {
+  const partyLines = unbound.map(p => {
     const setter = `with${toPascalCase(p.name)}`;
-    if (i === 0) {
+    if (p.kind === 'signer') {
       return `  .${setter}(Party.signer(signer))`;
     }
     return `  .${setter}(Party.address(${JSON.stringify(p.address)}))`;
   });
 
   const lines: string[] = [
-    `import { Client } from "./gen/typescript/${protocol.name}";`,
+    `import { Client } from "./${protocol.name}/protocol";`,
     'import { CardanoSigner, Party } from "tx3-sdk";',
     '',
     'const signer = await CardanoSigner.fromHex("addr_test1...", "deadbeef...");',

--- a/frontend/app/pages/protocol/details/tab/tryOut.tsx
+++ b/frontend/app/pages/protocol/details/tab/tryOut.tsx
@@ -9,6 +9,9 @@ import { Dropdown } from '~/components/ui/Dropdown';
 // Config
 import { getTrpForProfile } from '~/trp-config';
 
+// Internal
+import { profileHasData } from './sdks/quick-start';
+
 interface Props {
   protocol: Protocol;
 }
@@ -227,7 +230,11 @@ const Transaction: React.FunctionComponent<TransactionProps> = props => {
 };
 
 export function TabTryOut({ protocol }: Props) {
-  const profiles = protocol.profiles ?? [];
+  // Gate channels on actual profile presence in the protocol's `.tii`: a
+  // channel whose profile is an empty stub is not executable and must not be
+  // offered. When a missing profile is later published, it appears here
+  // without further UI work.
+  const profiles = (protocol.profiles ?? []).filter(profileHasData);
 
   return (
     <div className="container pt-8 pb-14 flex flex-col gap-8">

--- a/frontend/schema.graphql
+++ b/frontend/schema.graphql
@@ -107,12 +107,26 @@ type Protocol {
 	name: String!
 	scope: String!
 	repositoryUrl: String
+	"""
+	Project homepage, read from the `org.opencontainers.image.url`
+	annotation of the published OCI manifest. Populated on the detail
+	query (which pulls the manifest); `None` on list queries.
+	"""
+	homepageUrl: String
 	publishedDate: Int!
 	version: String!
 	readme: String
 	source: String
 	description: String
+	"""
+	Transactions in a stable order (sorted by name). The TII stores them in
+	a map, whose iteration order must never leak into the API: it would
+	reshuffle the UI on every load.
+	"""
 	transactions: [Tx!]!
+	"""
+	Parties in a stable order (sorted by name); see [`Self::transactions`].
+	"""
 	parties: [Party!]!
 	profiles: [Profile!]!
 	environment: [EnvironmentParam!]!


### PR DESCRIPTION
## Plan

`plans/feedback-cba-07-services-docs-registry-ux.md` (Trellis root `Brain/tx3`, owner `org/coder`) — items A, B, C, E and the registry half of D. Origin: user feedback ("UI lies", Bodega, Appendix).

## Done criterion (from the plan) and status

- **A — Try-out tab only shows channels with a real profile in the `.tii`**: met. Publishers emit empty stubs for every known channel (verified against the published `open-tx3/bodega-market` TII: `local`/`preview`/`preprod` are `{environment: {}, parties: {}}`), so the tab now filters profiles to those with actual parties or environment content. When plan 06 publishes the missing profiles they appear with no further UI work.
- **B — Snippets import from the generated protocol module, no `gen/` in any language**: met. TS `./{name}/protocol` (the generated `protocol.ts`), Python `from {snake_name} import ...`, Go `"yourapp/{name}"` (generated package name is `protocol`), Rust was already clean (`use {snake_name}::Client`). The setup-step note now states the real default codegen output dir (`.tx3/codegen/{plugin}/{name}/` per trix `CodegenConfig::output_dir`) instead of the nonexistent `./gen/...`.
- **C — Transactions/parties order stable across reloads**: met. Root cause was backend resolvers iterating the TII `HashMap`s; both resolvers now sort by name.
- **D (registry half) — homepage rendered; `project_info_ref` listable**: implemented. `homepageUrl` is read from the `org.opencontainers.image.url` OCI manifest annotation on the detail pull and rendered in the info panel. The Activity match detail now lists the matched transaction's reference inputs (`txhash#index`), which is the discovery surface for ref-UTxO parameters such as bodega's `project_info_ref` — the values real on-chain transactions used. Note: it renders for bodega once `trix publish` emits the homepage annotation and bodega is republished (see companion PR open-tx3/bodega-protocols and the follow-up plan in the Trellis root).
- **E — signer on `withParticipant`/`withUser`, script addresses from env**: met. The signer now goes on the first non-script unbound party; script parties (`*script`) take a bech32 address from the profile environment when one is published, and an explicit `<name script address>` placeholder otherwise — never the caller's own signer/address. Verified against the published bodega (signer was landing on `positionscript`) and hydra-heads (signer was landing on `commitscript`) TIIs.

## Verification run

- `cargo check` and `cargo test` (backend): 21 unit tests pass. The 9 `db_matches` + graphql integration tests fail locally with `DATABASE_URL must be set` — pre-existing environmental requirement (live Postgres), unrelated to this change (`db.rs` untouched); reported as a finding.
- `pnpm lint`, `pnpm typecheck` (frontend): clean.
- `pnpm codegen` regenerated `@types/graphql.d.ts` from the backend-exported SDL (`frontend/schema.graphql` synced from `cargo test regenerate_sdl` output).
- Functional check of the snippet generators against the real published bodega-market and hydra-heads TII shapes: empty channels filtered; signer on `withUser`/`withParticipant`; script parties get named placeholders; imports carry no `gen/` segment.

## Escalations

None for this PR. Residual work (trix `[protocol].homepage` → OCI annotation emission; bodega `.tx3` reference-datum read to drop the `project_info_ref` caller param; SDKs-tab channel dropdown gating) is filed as a draft plan in the Trellis root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
